### PR TITLE
Samples asked for wrong key and misused .exceptionally()

### DIFF
--- a/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
+++ b/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
@@ -57,7 +57,7 @@ class PubSub {
                 "  -p|--port     Port to connect to on the endpoint\n"+
                 "  -r|--rootca   Path to the root certificate\n"+
                 "  -c|--cert     Path to the IoT thing certificate\n"+
-                "  -k|--key      Path to the IoT thing public key\n"+
+                "  -k|--key      Path to the IoT thing private key\n"+
                 "  -t|--topic    Topic to subscribe/publish to (optional)\n"+
                 "  -m|--message  Message to publish (optional)\n"+
                 "  -n|--count    Number of messages to publish (optional)\n" +
@@ -213,13 +213,13 @@ class PubSub {
 
             try(MqttClientConnection connection = builder.build()) {
 
-                CompletableFuture<Boolean> connected = connection.connect()
-                        .exceptionally((ex) -> {
-                            System.out.println("Exception occurred during connect: " + ex.toString());
-                            return null;
-                        });
-                boolean sessionPresent = connected.get();
-                System.out.println("Connected to " + (!sessionPresent ? "new" : "existing") + " session!");
+                CompletableFuture<Boolean> connected = connection.connect();
+                try {
+                    boolean sessionPresent = connected.get();
+                    System.out.println("Connected to " + (!sessionPresent ? "new" : "existing") + " session!");
+                } catch (Exception ex) {
+                    throw new RuntimeException("Exception occurred during connect", ex);
+                }
 
                 CompletableFuture<Integer> subscribed = connection.subscribe(topic, QualityOfService.AT_LEAST_ONCE, (message) -> {
                     try {

--- a/samples/PubSubStress/src/main/java/pubsubstress/PubSubStress.java
+++ b/samples/PubSubStress/src/main/java/pubsubstress/PubSubStress.java
@@ -66,7 +66,7 @@ class PubSubStress {
                 "  -e|--endpoint AWS IoT service endpoint hostname\n"+
                 "  -r|--rootca   Path to the root certificate\n"+
                 "  -c|--cert     Path to the IoT thing certificate\n"+
-                "  -k|--key      Path to the IoT thing public key\n"+
+                "  -k|--key      Path to the IoT thing private key\n"+
                 "  -t|--topic    Topic to subscribe/publish to (optional)\n"+
                 "  -m|--message  Message to publish (optional)\n"+
                 "  -n|--count    Number of messages to publish (optional)\n"+

--- a/samples/RawPubSub/src/main/java/rawpubsub/RawPubSub.java
+++ b/samples/RawPubSub/src/main/java/rawpubsub/RawPubSub.java
@@ -54,7 +54,7 @@ class RawPubSub {
                 "  -e|--endpoint AWS IoT service endpoint hostname\n"+
                 "  -r|--rootca   Path to the root certificate\n"+
                 "  -c|--cert     Path to the IoT thing certificate\n"+
-                "  -k|--key      Path to the IoT thing public key\n"+
+                "  -k|--key      Path to the IoT thing private key\n"+
                 "  -t|--topic    Topic to subscribe/publish to (optional)\n"+
                 "  -m|--message  Message to publish (optional)\n"+
                 "  -n|--count    Number of messages to publish (optional)"+
@@ -216,13 +216,13 @@ class RawPubSub {
 
                 try (MqttClientConnection connection = new MqttClientConnection(config)) {
 
-                    CompletableFuture<Boolean> connected = connection.connect()
-                        .exceptionally((ex) -> {
-                            System.out.println("Exception occurred during connect: " + ex.toString());
-                            return null;
-                        });
-                    boolean sessionPresent = connected.get();
-                    System.out.println("Connected to " + (!sessionPresent ? "new" : "existing") + " session!");
+                    CompletableFuture<Boolean> connected = connection.connect();
+                    try {
+                        boolean sessionPresent = connected.get();
+                        System.out.println("Connected to " + (!sessionPresent ? "new" : "existing") + " session!");
+                    } catch (Exception ex) {
+                        throw new RuntimeException("Exception occurred during connect", ex);
+                    }
 
                     CompletableFuture<Integer> subscribed = connection.subscribe(topic, QualityOfService.AT_LEAST_ONCE, (message) -> {
                         try {

--- a/samples/Shadow/src/main/java/shadow/ShadowSample.java
+++ b/samples/Shadow/src/main/java/shadow/ShadowSample.java
@@ -68,7 +68,7 @@ public class ShadowSample {
                 "  -e|--endpoint AWS IoT service endpoint hostname\n"+
                 "  -r|--rootca   Path to the root certificate\n"+
                 "  -c|--cert     Path to the IoT thing certificate\n"+
-                "  -k|--key      Path to the IoT thing public key"
+                "  -k|--key      Path to the IoT thing private key"
         );
     }
 
@@ -243,13 +243,13 @@ public class ShadowSample {
             try(MqttClientConnection connection = builder.build()) {
                 shadow = new IotShadowClient(connection);
 
-                CompletableFuture<Boolean> connected = connection.connect()
-                        .exceptionally((ex) -> {
-                            System.out.println("Exception occurred during connect: " + ex.toString());
-                            return null;
-                        });
-                boolean sessionPresent = connected.get();
-                System.out.println("Connected to " + (!sessionPresent ? "clean" : "existing") + " session!");
+                CompletableFuture<Boolean> connected = connection.connect();
+                try {
+                    boolean sessionPresent = connected.get();
+                    System.out.println("Connected to " + (!sessionPresent ? "clean" : "existing") + " session!");
+                } catch (Exception ex) {
+                    throw new RuntimeException("Exception occurred during connect", ex);
+                }
 
                 System.out.println("Subscribing to shadow delta events...");
                 ShadowDeltaUpdatedSubscriptionRequest requestShadowDeltaUpdated = new ShadowDeltaUpdatedSubscriptionRequest();


### PR DESCRIPTION
- Ask for "private" key, not "public"
- Our misuse of `CompletableFuture.exceptionally()` was causing `NullPointerExceptions` that buried the real error message. Just catch error and propagate it with a message to give context.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
