### PR TITLE
Disable HTML escape option when marshalling to/from JSON

### DIFF
--- a/sdk/src/main/java/software/amazon/awssdk/iot/iotjobs/IotJobsClient.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/iotjobs/IotJobsClient.java
@@ -68,6 +68,7 @@ public class IotJobsClient {
 
     private Gson getGson() {
         GsonBuilder gson = new GsonBuilder();
+        gson.disableHtmlEscaping();
         gson.registerTypeAdapter(Timestamp.class, new Timestamp.Serializer());
         gson.registerTypeAdapter(Timestamp.class, new Timestamp.Deserializer());
         addTypeAdapters(gson);

--- a/sdk/src/main/java/software/amazon/awssdk/iot/iotjobs/IotJobsClient.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/iotjobs/IotJobsClient.java
@@ -76,8 +76,8 @@ public class IotJobsClient {
     }
 
     private void addTypeAdapters(GsonBuilder gson) {
-        gson.registerTypeAdapter(JobStatus.class, new EnumSerializer<JobStatus>());
         gson.registerTypeAdapter(RejectedErrorCode.class, new EnumSerializer<RejectedErrorCode>());
+        gson.registerTypeAdapter(JobStatus.class, new EnumSerializer<JobStatus>());
     }
 
     public CompletableFuture<Integer> SubscribeToJobExecutionsChangedEvents(
@@ -93,9 +93,13 @@ public class IotJobsClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            JobExecutionsChangedEvent response = gson.fromJson(payload, JobExecutionsChangedEvent.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                JobExecutionsChangedEvent response = gson.fromJson(payload, JobExecutionsChangedEvent.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -120,9 +124,13 @@ public class IotJobsClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            StartNextJobExecutionResponse response = gson.fromJson(payload, StartNextJobExecutionResponse.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                StartNextJobExecutionResponse response = gson.fromJson(payload, StartNextJobExecutionResponse.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -153,9 +161,13 @@ public class IotJobsClient {
         }
         topic = topic.replace("{jobId}", request.jobId);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            RejectedError response = gson.fromJson(payload, RejectedError.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                RejectedError response = gson.fromJson(payload, RejectedError.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -180,9 +192,13 @@ public class IotJobsClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            NextJobExecutionChangedEvent response = gson.fromJson(payload, NextJobExecutionChangedEvent.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                NextJobExecutionChangedEvent response = gson.fromJson(payload, NextJobExecutionChangedEvent.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -213,9 +229,13 @@ public class IotJobsClient {
         }
         topic = topic.replace("{jobId}", request.jobId);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            RejectedError response = gson.fromJson(payload, RejectedError.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                RejectedError response = gson.fromJson(payload, RejectedError.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -246,9 +266,13 @@ public class IotJobsClient {
         }
         topic = topic.replace("{jobId}", request.jobId);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            UpdateJobExecutionResponse response = gson.fromJson(payload, UpdateJobExecutionResponse.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                UpdateJobExecutionResponse response = gson.fromJson(payload, UpdateJobExecutionResponse.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -300,9 +324,13 @@ public class IotJobsClient {
         }
         topic = topic.replace("{jobId}", request.jobId);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            DescribeJobExecutionResponse response = gson.fromJson(payload, DescribeJobExecutionResponse.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                DescribeJobExecutionResponse response = gson.fromJson(payload, DescribeJobExecutionResponse.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -342,9 +370,13 @@ public class IotJobsClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            GetPendingJobExecutionsResponse response = gson.fromJson(payload, GetPendingJobExecutionsResponse.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                GetPendingJobExecutionsResponse response = gson.fromJson(payload, GetPendingJobExecutionsResponse.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -369,9 +401,13 @@ public class IotJobsClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            RejectedError response = gson.fromJson(payload, RejectedError.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                RejectedError response = gson.fromJson(payload, RejectedError.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -396,9 +432,13 @@ public class IotJobsClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            RejectedError response = gson.fromJson(payload, RejectedError.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                RejectedError response = gson.fromJson(payload, RejectedError.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }

--- a/sdk/src/main/java/software/amazon/awssdk/iot/iotjobs/IotJobsClient.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/iotjobs/IotJobsClient.java
@@ -76,8 +76,8 @@ public class IotJobsClient {
     }
 
     private void addTypeAdapters(GsonBuilder gson) {
-        gson.registerTypeAdapter(RejectedErrorCode.class, new EnumSerializer<RejectedErrorCode>());
         gson.registerTypeAdapter(JobStatus.class, new EnumSerializer<JobStatus>());
+        gson.registerTypeAdapter(RejectedErrorCode.class, new EnumSerializer<RejectedErrorCode>());
     }
 
     public CompletableFuture<Integer> SubscribeToJobExecutionsChangedEvents(

--- a/sdk/src/main/java/software/amazon/awssdk/iot/iotjobs/IotJobsClient.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/iotjobs/IotJobsClient.java
@@ -98,7 +98,9 @@ public class IotJobsClient {
                 JobExecutionsChangedEvent response = gson.fromJson(payload, JobExecutionsChangedEvent.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -129,7 +131,9 @@ public class IotJobsClient {
                 StartNextJobExecutionResponse response = gson.fromJson(payload, StartNextJobExecutionResponse.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -166,7 +170,9 @@ public class IotJobsClient {
                 RejectedError response = gson.fromJson(payload, RejectedError.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -197,7 +203,9 @@ public class IotJobsClient {
                 NextJobExecutionChangedEvent response = gson.fromJson(payload, NextJobExecutionChangedEvent.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -234,7 +242,9 @@ public class IotJobsClient {
                 RejectedError response = gson.fromJson(payload, RejectedError.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -271,7 +281,9 @@ public class IotJobsClient {
                 UpdateJobExecutionResponse response = gson.fromJson(payload, UpdateJobExecutionResponse.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -329,7 +341,9 @@ public class IotJobsClient {
                 DescribeJobExecutionResponse response = gson.fromJson(payload, DescribeJobExecutionResponse.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -375,7 +389,9 @@ public class IotJobsClient {
                 GetPendingJobExecutionsResponse response = gson.fromJson(payload, GetPendingJobExecutionsResponse.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -406,7 +422,9 @@ public class IotJobsClient {
                 RejectedError response = gson.fromJson(payload, RejectedError.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -437,7 +455,9 @@ public class IotJobsClient {
                 RejectedError response = gson.fromJson(payload, RejectedError.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);

--- a/sdk/src/main/java/software/amazon/awssdk/iot/iotshadow/IotShadowClient.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/iotshadow/IotShadowClient.java
@@ -64,6 +64,7 @@ public class IotShadowClient {
 
     private Gson getGson() {
         GsonBuilder gson = new GsonBuilder();
+        gson.disableHtmlEscaping();
         gson.registerTypeAdapter(Timestamp.class, new Timestamp.Serializer());
         gson.registerTypeAdapter(Timestamp.class, new Timestamp.Deserializer());
         addTypeAdapters(gson);

--- a/sdk/src/main/java/software/amazon/awssdk/iot/iotshadow/IotShadowClient.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/iotshadow/IotShadowClient.java
@@ -92,7 +92,9 @@ public class IotShadowClient {
                 ErrorResponse response = gson.fromJson(payload, ErrorResponse.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -153,7 +155,9 @@ public class IotShadowClient {
                 ShadowDeltaUpdatedEvent response = gson.fromJson(payload, ShadowDeltaUpdatedEvent.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -184,7 +188,9 @@ public class IotShadowClient {
                 UpdateShadowResponse response = gson.fromJson(payload, UpdateShadowResponse.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -230,7 +236,9 @@ public class IotShadowClient {
                 DeleteShadowResponse response = gson.fromJson(payload, DeleteShadowResponse.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -261,7 +269,9 @@ public class IotShadowClient {
                 GetShadowResponse response = gson.fromJson(payload, GetShadowResponse.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -292,7 +302,9 @@ public class IotShadowClient {
                 ShadowUpdatedEvent response = gson.fromJson(payload, ShadowUpdatedEvent.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -323,7 +335,9 @@ public class IotShadowClient {
                 ErrorResponse response = gson.fromJson(payload, ErrorResponse.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);
@@ -354,7 +368,9 @@ public class IotShadowClient {
                 ErrorResponse response = gson.fromJson(payload, ErrorResponse.class);
                 handler.accept(response);
             } catch (Exception e) {
-                exceptionHandler.accept(e);
+                if (exceptionHandler != null) {
+                    exceptionHandler.accept(e);
+                }
             }
         };
         return connection.subscribe(topic, qos, messageHandler);

--- a/sdk/src/main/java/software/amazon/awssdk/iot/iotshadow/IotShadowClient.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/iotshadow/IotShadowClient.java
@@ -87,9 +87,13 @@ public class IotShadowClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            ErrorResponse response = gson.fromJson(payload, ErrorResponse.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                ErrorResponse response = gson.fromJson(payload, ErrorResponse.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -144,9 +148,13 @@ public class IotShadowClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            ShadowDeltaUpdatedEvent response = gson.fromJson(payload, ShadowDeltaUpdatedEvent.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                ShadowDeltaUpdatedEvent response = gson.fromJson(payload, ShadowDeltaUpdatedEvent.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -171,9 +179,13 @@ public class IotShadowClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            UpdateShadowResponse response = gson.fromJson(payload, UpdateShadowResponse.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                UpdateShadowResponse response = gson.fromJson(payload, UpdateShadowResponse.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -213,9 +225,13 @@ public class IotShadowClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            DeleteShadowResponse response = gson.fromJson(payload, DeleteShadowResponse.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                DeleteShadowResponse response = gson.fromJson(payload, DeleteShadowResponse.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -240,9 +256,13 @@ public class IotShadowClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            GetShadowResponse response = gson.fromJson(payload, GetShadowResponse.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                GetShadowResponse response = gson.fromJson(payload, GetShadowResponse.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -267,9 +287,13 @@ public class IotShadowClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            ShadowUpdatedEvent response = gson.fromJson(payload, ShadowUpdatedEvent.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                ShadowUpdatedEvent response = gson.fromJson(payload, ShadowUpdatedEvent.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -294,9 +318,13 @@ public class IotShadowClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            ErrorResponse response = gson.fromJson(payload, ErrorResponse.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                ErrorResponse response = gson.fromJson(payload, ErrorResponse.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }
@@ -321,9 +349,13 @@ public class IotShadowClient {
         }
         topic = topic.replace("{thingName}", request.thingName);
         Consumer<MqttMessage> messageHandler = (message) -> {
-            String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-            ErrorResponse response = gson.fromJson(payload, ErrorResponse.class);
-            handler.accept(response);
+            try {
+                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                ErrorResponse response = gson.fromJson(payload, ErrorResponse.class);
+                handler.accept(response);
+            } catch (Exception e) {
+                exceptionHandler.accept(e);
+            }
         };
         return connection.subscribe(topic, qos, messageHandler);
     }


### PR DESCRIPTION
Don't escape the contents of valid JSON strings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
