### PR TITLE
Update PubSub showing x509 credentials with a proxy

### DIFF
--- a/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
+++ b/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
@@ -258,8 +258,9 @@ class PubSub {
                 builder.withWebsockets(true);
                 builder.withWebsocketSigningRegion(region);
 
+                HttpProxyOptions proxyOptions = null;
                 if (proxyHost != null && proxyPort > 0) {
-                    HttpProxyOptions proxyOptions = new HttpProxyOptions();
+                    proxyOptions = new HttpProxyOptions();
                     proxyOptions.setHost(proxyHost);
                     proxyOptions.setPort(proxyPort);
 
@@ -278,7 +279,8 @@ class PubSub {
                                     .withTlsContext(x509TlsContext)
                                     .withEndpoint(x509Endpoint)
                                     .withRoleAlias(x509RoleAlias)
-                                    .withThingName(x509Thing);
+                                    .withThingName(x509Thing)
+                                    .withProxyOptions(proxyOptions);
                             try (X509CredentialsProvider provider = x509builder.build()) {
                                 builder.withWebsocketCredentialsProvider(provider);
                             }

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.5.6</version>
+      <version>0.5.7</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Add proxy support to x509 options in the BasicPubSub sample

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
