### PR TITLE
Unified dependencies with aws-crt:android

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ brew install maven
 *   CMake 3.1+
 *   Clang 3.9+ or GCC 4.4+ or MSVC 2015+
 
+
+
 ## Build IoT Device SDK from source
 ```
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git
@@ -62,7 +64,7 @@ mvn clean install
 Supports API 26 or newer.
 NOTE: The shadow sample does not currently complete on android due to its dependence on stdin keyboard input.
 ```sh
-git clone --branch v0.5.4 https://github.com/awslabs/aws-crt-java.git
+git clone --recursive --branch v0.6.2 https://github.com/awslabs/aws-crt-java.git
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git
 cd aws-crt-java/android
 ./gradlew connectedCheck # optional, will run the unit tests on any connected devices/emulators

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ brew install maven
 *   CMake 3.1+
 *   Clang 3.9+ or GCC 4.4+ or MSVC 2015+
 
-
-
 ## Build IoT Device SDK from source
 ```
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,7 +50,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(":iotdevicesdk")
-    implementation 'software.amazon.awssdk.crt:aws-crt:0.6.2'
+    implementation 'software.amazon.awssdk.crt:android:0.6.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core:1.2.0'

--- a/android/app/src/main/assets/.gitignore
+++ b/android/app/src/main/assets/.gitignore
@@ -1,2 +1,3 @@
 *.txt
 *.pem
+*.crt

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -124,23 +124,18 @@ task androidDocsJar(type: Jar) {
 afterEvaluate {
     publishing {
         publications {
-            // Creates a Maven publication called "release".
             release(MavenPublication) {
-                // Applies the component for the release build variant.
                 from components.release
 
-                // You can then customize attributes of the publication as shown below.
-                groupId = 'software.amazon.awssdk.crt.iotdevicesdk'
-                artifactId = 'aws-iot-device-sdk'
+                groupId = 'software.amazon.awssdk.iotdevicesdk'
+                artifactId = 'android'
                 version = android.defaultConfig.versionName
             }
-            // Creates a Maven publication called “debug”.
             debug(MavenPublication) {
-                // Applies the component for the debug build variant.
                 from components.debug
 
-                groupId = 'software.amazon.awssdk.crt.iotdevicesdk'
-                artifactId = 'aws-iot-device-sdk'
+                groupId = 'software.amazon.awssdk.iotdevicesdk'
+                artifactId = 'android'
                 version = android.defaultConfig.versionName + '-SNAPSHOT'
             }
         }

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -32,7 +32,7 @@ ext {
             def patch = version['patch'] as int
             return (major * 1000) + (minor * 100) + patch
         } catch (Exception ex) {
-            return 0
+            return 1000
         }
     }
     gitVersionTag = {
@@ -48,8 +48,8 @@ android {
     defaultConfig {
         minSdkVersion 26
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        versionCode = gitVersionCode()
+        versionName = gitVersionName()
         ndkVersion "21.0.6113669"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -87,7 +87,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'software.amazon.awssdk.crt:aws-crt:0.6.2'
+    implementation 'software.amazon.awssdk.crt:android:0.6.2'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-iot-device-sdk-java-v2/issues/69

*Description of changes:* There was a mixup between the aws-crt and android artifacts specified by the aws-crt-java package. This change fixes the build scripts to depend correctly on the android artifact.

Tested by cleaning both repositories and following the android build instructions from README.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
