### PR TITLE
All V2 SDK samples can share policies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ repositories {
     }
 }
 
-dependencies { 
+dependencies {
     implementation 'software.amazon.awssdk.crt:android:0.6.2'
 }
 ```
@@ -165,7 +165,7 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }
@@ -240,7 +240,7 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }
@@ -261,16 +261,16 @@ Source: `samples/Identity`
 cd ~/samples/Identity
 
 Run the sample using CreateKeysAndCertificate:
- 
+
 ```
-mvn exec:java -Dexec.mainClass="identity.FleetProvisioningSample" -Dexec.args="--endpoint <endpoint> --rootca <root ca path> 
+mvn exec:java -Dexec.mainClass="identity.FleetProvisioningSample" -Dexec.args="--endpoint <endpoint> --rootca <root ca path>
 --cert <cert path> --key <private key path> --templateName <templatename> --templateParameters <templateParams>"
 ```
 
 Run the sample using CreateCertificateFromCsr:
- 
+
 ```
-mvn exec:java -Dexec.mainClass="identity.FleetProvisioningSample" -Dexec.args="--endpoint <endpoint> --rootca <root ca path> 
+mvn exec:java -Dexec.mainClass="identity.FleetProvisioningSample" -Dexec.args="--endpoint <endpoint> --rootca <root ca path>
 --cert <cert path> --key <private key path> --templateName <templatename> --templateParameters <templateParams> --csr <csr path>"
 ```
 
@@ -293,7 +293,7 @@ and receive.
       "Resource": [
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create/json",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create-from-csr/json",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename<b>/provision/json"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename</b>/provision/json"
       ]
     },
     {
@@ -307,14 +307,14 @@ and receive.
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create/json/rejected",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create-from-csr/json/accepted",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create-from-csr/json/rejected",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename<b>/provision/json/accepted",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename<b>/provision/json/rejected"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename</b>/provision/json/accepted",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename</b>/provision/json/rejected"
       ]
     },
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }

--- a/android/app/src/main/java/software/amazon/awssdk/iotsamples/MainActivity.kt
+++ b/android/app/src/main/java/software/amazon/awssdk/iotsamples/MainActivity.kt
@@ -139,7 +139,7 @@ class MainActivity : AppCompatActivity(), AdapterView.OnItemSelectedListener {
             )
             if (name == "pubsub.PubSub") {
                 args.addAll(arrayOf(
-                    "--topic", assetContentsOr("topic.txt", "/samples/test"),
+                    "--topic", assetContentsOr("topic.txt", "test/topic"),
                     "--message", assetContentsOr("message.txt", "Hello World From Android")))
             } else if (name in arrayOf("jobs.JobsSample", "shadow.ShadowSample")) {
                 args.addAll(arrayOf(

--- a/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
+++ b/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
@@ -22,16 +22,17 @@ import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 import software.amazon.awssdk.iot.iotjobs.model.RejectedError;
 
 import java.io.UnsupportedEncodingException;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 class PubSub {
-    static String clientId = "samples-client-id";
+    static String clientId = "test-" + UUID.randomUUID().toString();
     static String rootCaPath;
     static String certPath;
     static String keyPath;
     static String endpoint;
-    static String topic = "/samples/test";
+    static String topic = "test/topic";
     static String message = "Hello World!";
     static int    messagesToPublish = 10;
     static boolean showHelp = false;

--- a/samples/Greengrass/src/main/java/greengrass/BasicDiscovery.java
+++ b/samples/Greengrass/src/main/java/greengrass/BasicDiscovery.java
@@ -35,7 +35,7 @@ class BasicDiscovery {
     static String certPath;
     static String keyPath;
     static String region = "us-east-1";
-    static String topic = "/samples/test";
+    static String topic = "test/topic";
     static String mode = "both";
     static boolean showHelp = false;
 
@@ -246,7 +246,7 @@ class BasicDiscovery {
                         group.getGGGroupId(), core.getThingArn(), dnsOrIp, port));
 
                 final AwsIotMqttConnectionBuilder connectionBuilder = AwsIotMqttConnectionBuilder.newMtlsBuilderFromPath(certPath, keyPath)
-                        .withClientId("RaspberryPi")
+                        .withClientId("test-" + UUID.randomUUID().toString())
                         .withPort(port.shortValue())
                         .withEndpoint(dnsOrIp)
                         .withBootstrap(bootstrap)

--- a/samples/Identity/src/main/java/identity/FleetProvisioningSample.java
+++ b/samples/Identity/src/main/java/identity/FleetProvisioningSample.java
@@ -36,11 +36,12 @@ import java.util.Map;
 import com.google.gson.Gson;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 public class FleetProvisioningSample {
-    static String clientId = "samples-client-id";
+    static String clientId = "test-" + UUID.randomUUID().toString();
     static String rootCaPath;
     static String certPath;
     static String keyPath;

--- a/samples/Jobs/src/main/java/jobs/JobsSample.java
+++ b/samples/Jobs/src/main/java/jobs/JobsSample.java
@@ -32,11 +32,12 @@ import software.amazon.awssdk.iot.iotjobs.model.UpdateJobExecutionSubscriptionRe
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 public class JobsSample {
-    static String clientId = "samples-client-id";
+    static String clientId = "test-" + UUID.randomUUID().toString();
     static String thingName;
     static String rootCaPath;
     static String certPath;

--- a/samples/PubSubStress/src/main/java/pubsubstress/PubSubStress.java
+++ b/samples/PubSubStress/src/main/java/pubsubstress/PubSubStress.java
@@ -27,12 +27,12 @@ import java.util.concurrent.TimeUnit;
 class PubSubStress {
     private static final int PROGRESS_OP_COUNT = 100;
 
-    static String clientId = "samples-client-id";
+    static String clientId = "test-" + UUID.randomUUID().toString();
     static String rootCaPath;
     static String certPath;
     static String keyPath;
     static String endpoint;
-    static String topic = "/samples/test";
+    static String topic = "test/topic";
     static String message = "Hello World!";
     static int    messagesToPublish = 5000;
     static boolean showHelp = false;

--- a/samples/RawPubSub/src/main/java/rawpubsub/RawPubSub.java
+++ b/samples/RawPubSub/src/main/java/rawpubsub/RawPubSub.java
@@ -18,16 +18,17 @@ import software.amazon.awssdk.iot.iotjobs.model.RejectedError;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 class RawPubSub {
-    static String clientId = "samples-client-id";
+    static String clientId = "test-" + UUID.randomUUID().toString();
     static String rootCaPath;
     static String certPath;
     static String keyPath;
     static String endpoint;
-    static String topic = "/samples/test";
+    static String topic = "test/topic";
     static String message = "Hello World!";
     static int    messagesToPublish = 10;
     static boolean showHelp = false;

--- a/samples/Shadow/src/main/java/shadow/ShadowSample.java
+++ b/samples/Shadow/src/main/java/shadow/ShadowSample.java
@@ -31,9 +31,10 @@ import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.Scanner;
+import java.util.UUID;
 
 public class ShadowSample {
-    static String clientId = "samples-client-id";
+    static String clientId = "test-" + UUID.randomUUID().toString();
     static String thingName;
     static String rootCaPath;
     static String certPath;


### PR DESCRIPTION
ISSUE:
Currently, the "Getting Started Kit" vended by the IoT console vends a policy that doesn't match the strings used by any V2 SDK samples. So they fail right off the bat 😢

SOLUTION:
Let's get all the V2 SDKs using the same strings, then we can create a policy to fit them all. I'd like to put wildcards in the new policy so users can toy around a little bit, but include the word "test" everywhere so they feel inclined to change it before they ship.

Also, let's get all the samples putting randomness into the client-id, since colliding IDs are a frequent source of confusion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
