### PR TITLE
OSX TLS ReadMe Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ to Java by the [aws-crt-java](https://github.com/awslabs/aws-crt-java) package.
 
 
 *__Jump To:__*
+* [OSX Only TLS Behavior](#OSX-Only-TLS-Behavior)
 * [Installation](#Installation)
 * [Samples](samples)
 * [Getting Help](#Getting-Help)
 * [Giving Feedback and Contributions](#Giving-Feedback-and-Contributions)
 * [More Resources](#More-Resources)
 
-# OSX Only TLS Behavior
+
+## OSX Only TLS Behavior
 
 Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to Java by the [aws-crt-java](https://github.com/awslabs/aws-crt-java) package.
 
 
 *__Jump To:__*
-* [OSX-Only TLS Behavior](#OSX-Only-TLS-Behavior)
+* [Mac-Only TLS Behavior](#Mac-Only-TLS-Behavior)
 * [Installation](#Installation)
 * [Samples](samples)
 * [Getting Help](#Getting-Help)
@@ -24,9 +24,9 @@ to Java by the [aws-crt-java](https://github.com/awslabs/aws-crt-java) package.
 * [More Resources](#More-Resources)
 
 
-## OSX-Only TLS Behavior
+## Mac-Only TLS Behavior
 
-Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ to Java by the [aws-crt-java](https://github.com/awslabs/aws-crt-java) package.
 
 ## Mac-Only TLS Behavior
 
-Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+
+```
+static: certificate has an existing certificate-key pair that was previously imported into the Keychain.  Using key from Keychain instead of the one provided.
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to Java by the [aws-crt-java](https://github.com/awslabs/aws-crt-java) package.
 * [More Resources](#More-Resources)
 
 
-## OSX Only TLS Behavior
+## OSX-Only TLS Behavior
 
 Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to Java by the [aws-crt-java](https://github.com/awslabs/aws-crt-java) package.
 
 
 *__Jump To:__*
-* [OSX Only TLS Behavior](#OSX-Only-TLS-Behavior)
+* [OSX-Only TLS Behavior](#OSX-Only-TLS-Behavior)
 * [Installation](#Installation)
 * [Samples](samples)
 * [Getting Help](#Getting-Help)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ to Java by the [aws-crt-java](https://github.com/awslabs/aws-crt-java) package.
 * [Giving Feedback and Contributions](#Giving-Feedback-and-Contributions)
 * [More Resources](#More-Resources)
 
+# OSX Only TLS Behavior
 
+Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 
 ## Installation
 


### PR DESCRIPTION
*Description of changes:*
Adding OSX TLS Keychain information to README.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
