### PR TITLE
Improve README titles and add TOC to samples README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS IoT SDK for Java v2
+# AWS IoT Device SDK for Java v2
 
 This document provides information about the AWS IoT device SDK for Java V2.
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,4 +1,14 @@
-# Samples
+# Sample apps for the AWS IoT Device SDK for Java v2
+
+* [Shadow](#shadow)
+* [Jobs](#jobs)
+* [fleet provisioning](#fleet-provisioning)
+
+**Additional sample apps not described below:**
+* [BasicPubSub](https://github.com/aws/aws-iot-device-sdk-java-v2/tree/master/samples/BasicPubSub)
+* [Greengrass](https://github.com/aws/aws-iot-device-sdk-java-v2/tree/master/samples/Greengrass)
+* [PubSubStress](https://github.com/aws/aws-iot-device-sdk-java-v2/tree/master/samples/PubSubStress)
+* [RawPubSub](https://github.com/aws/aws-iot-device-sdk-java-v2/tree/master/samples/RawPubSub)
 
 ## Shadow
 


### PR DESCRIPTION
*Issue #, if available:* N/A
*Description of changes:* Minor text-only edits to provide a smoother transition from the AWS IoT Core Developer Guide to the SDK documentation. (e.g. the links in https://docs.aws.amazon.com/iot/latest/developerguide/iot-connect-devices.html#iot-connect-device-sdks that land on an SDK README page.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
