### PR TITLE
Bump crt version to address hung connection issue

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.8.4</version>
+      <version>0.8.5</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
* Updates to CRT version 0.8.5, addressing an issue where a websocket mqtt connection could black hole if credentials sourcing fails


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
