### PR TITLE
Added CDL so main thread waits for subscribed messages to complete be…

### DIFF
--- a/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
+++ b/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
@@ -302,7 +302,6 @@ class PubSub {
                 });
 
                 subscribed.get();
-                countDownLatch.await();
 
                 int count = 0;
                 while (count++ < messagesToPublish) {
@@ -310,6 +309,8 @@ class PubSub {
                     published.get();
                     Thread.sleep(1000);
                 }
+                
+                countDownLatch.await();
 
                 CompletableFuture<Void> disconnected = connection.disconnect();
                 disconnected.get();

--- a/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
+++ b/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
@@ -22,8 +22,10 @@ import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 import software.amazon.awssdk.iot.iotjobs.model.RejectedError;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 
 class PubSub {
@@ -291,16 +293,16 @@ class PubSub {
                     throw new RuntimeException("Exception occurred during connect", ex);
                 }
 
+                CountDownLatch countDownLatch = new CountDownLatch(messagesToPublish);
+
                 CompletableFuture<Integer> subscribed = connection.subscribe(topic, QualityOfService.AT_LEAST_ONCE, (message) -> {
-                    try {
-                        String payload = new String(message.getPayload(), "UTF-8");
-                        System.out.println("MESSAGE: " + payload);
-                    } catch (UnsupportedEncodingException ex) {
-                        System.out.println("Unable to decode payload: " + ex.getMessage());
-                    }
+                    String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
+                    System.out.println("MESSAGE: " + payload);
+                    countDownLatch.countDown();
                 });
 
                 subscribed.get();
+                countDownLatch.await();
 
                 int count = 0;
                 while (count++ < messagesToPublish) {

--- a/samples/RawPubSub/src/main/java/rawpubsub/RawPubSub.java
+++ b/samples/RawPubSub/src/main/java/rawpubsub/RawPubSub.java
@@ -227,7 +227,6 @@ class RawPubSub {
                     });
 
                     subscribed.get();
-                    countDownLatch.await();
 
                     int count = 0;
                     while (count++ < messagesToPublish) {
@@ -235,6 +234,8 @@ class RawPubSub {
                         published.get();
                         Thread.sleep(1000);
                     }
+                    
+                    countDownLatch.await();
 
                     CompletableFuture<Void> disconnected = connection.disconnect();
                     disconnected.get();


### PR DESCRIPTION
…fore closing connection

Issue #, if available: 113

Description of changes: Adding a CountDownLatch so subscriber can finish receiving messages before the main thread closes the connection to the MQTT broker


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
