### PR TITLE
Update crt version to include support for nested tls via proxy

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.9.3</version>
+      <version>0.10.3</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
* Updates the crt dependency to a new version that correctly supports nested tls when using a proxy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
