### PR TITLE
add exec-maven-plugin to pubsub pom file

### DIFF
--- a/samples/BasicPubSub/pom.xml
+++ b/samples/BasicPubSub/pom.xml
@@ -20,4 +20,16 @@
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.4.0</version>
+                <configuration>
+                    <mainclass>main</mainclass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
fix following error: symbolic reference class is not accessible

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
