### PR TITLE
Update RawPubSub.java

### DIFF
--- a/samples/RawPubSub/src/main/java/rawpubsub/RawPubSub.java
+++ b/samples/RawPubSub/src/main/java/rawpubsub/RawPubSub.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 
-class RawPubSub {
+public class RawPubSub {
     static String clientId = "test-" + UUID.randomUUID().toString();
     static String rootCaPath;
     static String certPath;


### PR DESCRIPTION
Updated the class of `RawPubSub` to public, so it can be executed by maven/jvm

*Issue #, if available:*

`RawPubSub` class is not a public class therefore it's impossible to run the sample independently 

*Description of changes:*
Updated the `RawPubSub` class to be a public class. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
