### PR TITLE
Pull in s2n shutdown fix via crt; add resource waits on samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ mvn clean install
 ``` sh
 # NOTE: use the latest version of the CRT here
 
-git clone --branch v0.11.3 https://github.com/awslabs/aws-crt-java.git
+git clone --branch v0.11.5 https://github.com/awslabs/aws-crt-java.git
 
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git
 cd aws-crt-java
@@ -65,7 +65,7 @@ Supports API 26 or newer.
 NOTE: The shadow sample does not currently complete on android due to its dependence on stdin keyboard input.
 
 ``` sh
-git clone --recursive --branch v0.11.3 https://github.com/awslabs/aws-crt-java.git
+git clone --recursive --branch v0.11.5 https://github.com/awslabs/aws-crt-java.git
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git
 cd aws-crt-java/android
 ./gradlew connectedCheck # optional, will run the unit tests on any connected devices/emulators
@@ -86,7 +86,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'software.amazon.awssdk.crt:android:0.11.3'
+    implementation 'software.amazon.awssdk.crt:android:0.11.5'
 }
 ```
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,7 +50,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(":iotdevicesdk")
-    implementation 'software.amazon.awssdk.crt:android:0.11.3'
+    implementation 'software.amazon.awssdk.crt:android:0.11.5'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core:1.2.0'

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -87,7 +87,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'software.amazon.awssdk.crt:android:0.11.3'
+    implementation 'software.amazon.awssdk.crt:android:0.11.5'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <modules>
         <module>sdk</module>
         <module>samples/BasicPubSub</module>
+        <module>samples/Greengrass</module>
         <module>samples/Jobs</module>
         <module>samples/PubSubStress</module>
         <module>samples/RawPubSub</module>

--- a/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
+++ b/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
@@ -248,7 +248,8 @@ class PubSub {
                 .withClientId(clientId)
                 .withEndpoint(endpoint)
                 .withPort((short)port)
-                .withCleanSession(true);
+                .withCleanSession(true)
+                .withProtocolOperationTimeoutMs(60000);
 
             if (useWebsockets) {
                 builder.withWebsockets(true);

--- a/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
+++ b/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
@@ -6,6 +6,7 @@
 package pubsub;
 
 import software.amazon.awssdk.crt.CRT;
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.auth.credentials.X509CredentialsProvider;
 import software.amazon.awssdk.crt.http.HttpProxyOptions;
@@ -246,6 +247,7 @@ class PubSub {
                 .withConnectionEventCallbacks(callbacks)
                 .withClientId(clientId)
                 .withEndpoint(endpoint)
+                .withPort((short)port)
                 .withCleanSession(true);
 
             if (useWebsockets) {
@@ -318,6 +320,8 @@ class PubSub {
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
             System.out.println("Exception encountered: " + ex.toString());
         }
+
+        CrtResource.waitForNoResources();
 
         System.out.println("Complete!");
     }

--- a/samples/Identity/src/main/java/identity/FleetProvisioningSample.java
+++ b/samples/Identity/src/main/java/identity/FleetProvisioningSample.java
@@ -264,6 +264,7 @@ public class FleetProvisioningSample {
             System.out.println("Exception encountered: " + ex.toString());
         }
 
+        CrtResource.waitForNoResources();
         System.out.println("Complete!");
     }
 

--- a/samples/Jobs/src/main/java/jobs/JobsSample.java
+++ b/samples/Jobs/src/main/java/jobs/JobsSample.java
@@ -6,6 +6,7 @@
 package jobs;
 
 import software.amazon.awssdk.crt.CRT;
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.io.ClientBootstrap;
 import software.amazon.awssdk.crt.io.EventLoopGroup;
@@ -356,6 +357,7 @@ public class JobsSample {
             System.out.println("Exception encountered: " + ex.toString());
         }
 
+        CrtResource.waitForNoResources();
         System.out.println("Complete!");
     }
 }

--- a/samples/RawPubSub/src/main/java/rawpubsub/RawPubSub.java
+++ b/samples/RawPubSub/src/main/java/rawpubsub/RawPubSub.java
@@ -6,6 +6,7 @@
 package rawpubsub;
 
 import software.amazon.awssdk.crt.CRT;
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.io.ClientBootstrap;
 import software.amazon.awssdk.crt.io.EventLoopGroup;
@@ -245,6 +246,7 @@ class RawPubSub {
             System.out.println("Exception encountered: " + ex.toString());
         }
 
+        CrtResource.waitForNoResources();
         System.out.println("Complete!");
     }
 }

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.11.3</version>
+      <version>0.11.5</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
* Update to latest crt, pulling in the s2n connection shutdown fix for tls alert generation
* Add resource waits to all samples so that they can work as device advisor tests given the appropriate endpoint


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
