### PR TITLE
Add info about trust store issue on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ dependencies {
     implementation 'software.amazon.awssdk.crt:android:0.11.5'
 }
 ```
+#### Caution
+You will need to override and provide a ROOT_CERTIFICATE manually from one of the following [certificates](https://www.amazontrust.com/repository/). For overriding default trust store you can use following [method](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/ed802dce740895bcd3b0b91de30ec49407e34a87/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java#L151-L160). It's a [known problem](https://github.com/aws/aws-iot-device-sdk-java-v2/issues/157).
+
 
 ## Mac-Only TLS Behavior
 


### PR DESCRIPTION
Adds extra information and links to the known issue(#157) for the default trust store not being picked by the SDK automatically.

*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-java-v2/issues/157

*Description of changes:*
Documents how to make sdk work on Android as one needs to override default trust store. It would be explicit this is expected behavior f when using this SDK on Android and future users will save time before wondering why something isn't working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
