### PR TITLE
Updating aws-crt-java dependency

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.12.3</version>
+      <version>0.12.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
*Description of changes:*
Updating aws-crt-java submodules(recursive) to pick up fixes:

    - BUGFIX: More validation of HTTP/1.1 messages.
    - BUGFIX: High resolution clock fix on Windows.
    - BUGFIX: Non-ascii file open fix on Windows.
    - BUGFIX: Support non-desktop Windows.
    - BUGFIX: Fixing sending of S3 abort-multipart-upload message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
