### PR TITLE
Windows SNI with CA Override

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.12.6</version>
+      <version>0.12.8</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
* On Windows, perform SNI/server cert chain check even if the the root CA has been overridden

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
