### PR TITLE
Add public modifier to sample application main classes

### DIFF
--- a/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
+++ b/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 
-class PubSub {
+public class PubSub {
     static String clientId = "test-" + UUID.randomUUID().toString();
     static String rootCaPath;
     static String certPath;

--- a/samples/Greengrass/src/main/java/greengrass/BasicDiscovery.java
+++ b/samples/Greengrass/src/main/java/greengrass/BasicDiscovery.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 
 import static software.amazon.awssdk.iot.discovery.DiscoveryClient.TLS_EXT_ALPN;
 
-class BasicDiscovery {
+public class BasicDiscovery {
     static String thingName;
     static String rootCaPath;
     static String certPath;

--- a/samples/PubSubStress/src/main/java/pubsubstress/PubSubStress.java
+++ b/samples/PubSubStress/src/main/java/pubsubstress/PubSubStress.java
@@ -24,7 +24,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-class PubSubStress {
+public class PubSubStress {
     private static final int PROGRESS_OP_COUNT = 100;
 
     static String clientId = "test-" + UUID.randomUUID().toString();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `PubSub`, `PubSubStress`, and `BasicDiscovery` sample applications aren't public classes, so they can't be run in the way that the samples README suggests. This change makes these classes public, so these samples can be run.

Without this change, the following error is returned when you run one of these samples.
```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.0.0:java (default-cli) on project Greengrass: An exception occured while executing the Java class. The specified mainClass doesn't contain a main method with appropriate signature.: symbolic reference class is not public: class greengrass.BasicDiscovery, from org.codehaus.mojo.exec.ExecJavaMojo$1
```

Related: #144 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
