### PR TITLE
Fix CA override functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mvn clean install
 # NOTE: use the latest version of the CRT here
 
 
-git clone --branch v0.11.5 https://github.com/awslabs/aws-crt-java.git
+git clone --branch v0.14.0 https://github.com/awslabs/aws-crt-java.git
 
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git
 cd aws-crt-java
@@ -80,7 +80,7 @@ Supports API 26 or newer.
 NOTE: The shadow sample does not currently complete on android due to its dependence on stdin keyboard input.
 
 ``` sh
-git clone --recursive --branch v0.11.5 https://github.com/awslabs/aws-crt-java.git
+git clone --recursive --branch v0.14.0 https://github.com/awslabs/aws-crt-java.git
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git
 cd aws-crt-java/android
 ./gradlew connectedCheck # optional, will run the unit tests on any connected devices/emulators
@@ -101,7 +101,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'software.amazon.awssdk.crt:android:0.11.5'
+    implementation 'software.amazon.awssdk.crt:android:0.14.0'
 }
 ```
 #### Caution

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,7 +50,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(":iotdevicesdk")
-    implementation 'software.amazon.awssdk.crt:android:0.11.5'
+    implementation 'software.amazon.awssdk.crt:android:0.14.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core:1.2.0'

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -87,7 +87,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'software.amazon.awssdk.crt:android:0.11.5'
+    implementation 'software.amazon.awssdk.crt:android:0.14.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.13.2</version>
+      <version>0.14.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Update to aws-crt 0.14.0. This fixes the issue where "overrideDefaultTrustStore" functions did not actually override the system trust store on Linux and Apple platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
