### PR TITLE
Fix broken release

### DIFF
--- a/make-docs.py
+++ b/make-docs.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import os
+import shutil
+import subprocess
 
-if os.system("mvn clean package") != 0:
-    exit("maven clean package not built.")
+subprocess.run(['mvn', 'clean', 'javadoc:javadoc'], check=True)
 
-if os.system("mvn javadoc:javadoc") != 0:
-    exit("Maven javadoc plugin did not run correctly.")
+if os.path.exists('docs'):
+    shutil.rmtree('docs')
+shutil.copytree('sdk/target/site/apidocs', 'docs')

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -122,8 +122,6 @@
           <additionalJOptions>
             <additionalJOption>--allow-script-in-comments</additionalJOption>
           </additionalJOptions>
-          <reportOutputDirectory>../</reportOutputDirectory>
-          <destDir>docs</destDir>
           <windowtitle>AWS IoT Device SDK Java V2</windowtitle>
           <encoding>UTF-8</encoding>
           <docencoding>UTF-8</docencoding>
@@ -187,6 +185,20 @@
                 <id>attach-sources</id>
                 <goals>
                   <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- javadoc jar -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.3.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
When revamping docs, we accidentally removed the javadoc jar from release builds, causing maven to reject them. Now it's back.

Also, tweak make-docs.py script so it just copies javadoc from target/ to docs/. Trying to control its location via `reportOutputDirectory` and `destDir` wasn't always working how we expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
