### PR TITLE
Update to latest CRT to bring in several payload fixes

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.15.8</version>
+      <version>0.15.9</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
* Fixes a crash on Windows when with empty will message payloads
* Fixes a decoding error when receiving a message with empty payload

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
