### PR TITLE
fix string comparison

### DIFF
--- a/samples/Shadow/src/main/java/shadow/ShadowSample.java
+++ b/samples/Shadow/src/main/java/shadow/ShadowSample.java
@@ -170,7 +170,7 @@ public class ShadowSample {
     }
 
     static CompletableFuture<Void> changeShadowValue(String value) {
-        if (localValue == value) {
+        if (localValue.equals(value)) {
             System.out.println("Local value is already " + value);
             CompletableFuture<Void> result = new CompletableFuture<>();
             result.complete(null);


### PR DESCRIPTION
to compare strings in java you need to use `.equals(  )`

*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-java-v2/issues/191

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
