### PR TITLE
Run tests on multiple java versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,25 @@ jobs:
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+
+  java-compat:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 8
+          - 11
+          - 17
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.version }}
+          cache: maven
+      - name: Build ${{ env.PACKAGE_NAME }} + consumers
+        run: |
+          mvn -B test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,5 @@ jobs:
           cache: maven
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
+          java --version
           mvn -B test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,5 @@ jobs:
           cache: maven
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
-          java --version
+          java -version
           mvn -B test


### PR DESCRIPTION
**ISSUE**
We recently encountered a bug that only occurred in Java 9+.

**DESCRIPTION OF CHANGES**
Run tests on all long-term-support (LTS) versions of Java

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
