### PR TITLE
refactor(greengrass): add with-ers and remove the return from setters which broke compatibility

### DIFF
--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/BinaryMessage.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/BinaryMessage.java
@@ -40,8 +40,12 @@ public class BinaryMessage implements EventStreamJsonMessage {
     return null;
   }
 
-  public BinaryMessage setMessage(final byte[] message) {
+  public void setMessage(final byte[] message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public BinaryMessage withMessage(final byte[] message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ComponentDetails.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ComponentDetails.java
@@ -1,13 +1,11 @@
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;
-import java.lang.Object;
-import java.lang.Override;
-import java.lang.String;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
 public class ComponentDetails implements EventStreamJsonMessage {
   public static final String APPLICATION_MODEL_TYPE = "aws.greengrass#ComponentDetails";
@@ -61,8 +59,12 @@ public class ComponentDetails implements EventStreamJsonMessage {
     return null;
   }
 
-  public ComponentDetails setComponentName(final String componentName) {
+  public void setComponentName(final String componentName) {
     this.componentName = Optional.ofNullable(componentName);
+  }
+
+  public ComponentDetails withComponentName(final String componentName) {
+    setComponentName(componentName);
     return this;
   }
 
@@ -73,8 +75,12 @@ public class ComponentDetails implements EventStreamJsonMessage {
     return null;
   }
 
-  public ComponentDetails setVersion(final String version) {
+  public void setVersion(final String version) {
     this.version = Optional.ofNullable(version);
+  }
+
+  public ComponentDetails withVersion(final String version) {
+    setVersion(version);
     return this;
   }
 
@@ -92,12 +98,21 @@ public class ComponentDetails implements EventStreamJsonMessage {
     return null;
   }
 
+  public void setState(final String state) {
+    this.state = Optional.ofNullable(state);
+  }
+
+  public ComponentDetails withState(final String state) {
+    setState(state);
+    return this;
+  }
+
   public void setState(final LifecycleState state) {
     this.state = Optional.ofNullable(state.getValue());
   }
 
-  public ComponentDetails setState(final String state) {
-    this.state = Optional.ofNullable(state);
+  public ComponentDetails withState(final LifecycleState state) {
+    setState(state);
     return this;
   }
 
@@ -108,8 +123,12 @@ public class ComponentDetails implements EventStreamJsonMessage {
     return null;
   }
 
-  public ComponentDetails setConfiguration(final Map<String, Object> configuration) {
+  public void setConfiguration(final Map<String, Object> configuration) {
     this.configuration = Optional.ofNullable(configuration);
+  }
+
+  public ComponentDetails withConfiguration(final Map<String, Object> configuration) {
+    setConfiguration(configuration);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ComponentNotFoundError.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ComponentNotFoundError.java
@@ -50,8 +50,12 @@ public class ComponentNotFoundError extends GreengrassCoreIPCError implements Ev
     return null;
   }
 
-  public ComponentNotFoundError setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public ComponentNotFoundError withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ComponentUpdatePolicyEvents.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ComponentUpdatePolicyEvents.java
@@ -39,13 +39,17 @@ public class ComponentUpdatePolicyEvents implements EventStreamJsonMessage {
     return null;
   }
 
-  public ComponentUpdatePolicyEvents setPreUpdateEvent(
-      final PreComponentUpdateEvent preUpdateEvent) {
+  public void setPreUpdateEvent(final PreComponentUpdateEvent preUpdateEvent) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.preUpdateEvent = Optional.of(preUpdateEvent);
     this.setUnionMember = UnionMember.PRE_UPDATE_EVENT;
+  }
+
+  public ComponentUpdatePolicyEvents withPreUpdateEvent(
+      final PreComponentUpdateEvent preUpdateEvent) {
+    setPreUpdateEvent(preUpdateEvent);
     return this;
   }
 
@@ -56,13 +60,17 @@ public class ComponentUpdatePolicyEvents implements EventStreamJsonMessage {
     return null;
   }
 
-  public ComponentUpdatePolicyEvents setPostUpdateEvent(
-      final PostComponentUpdateEvent postUpdateEvent) {
+  public void setPostUpdateEvent(final PostComponentUpdateEvent postUpdateEvent) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.postUpdateEvent = Optional.of(postUpdateEvent);
     this.setUnionMember = UnionMember.POST_UPDATE_EVENT;
+  }
+
+  public ComponentUpdatePolicyEvents withPostUpdateEvent(
+      final PostComponentUpdateEvent postUpdateEvent) {
+    setPostUpdateEvent(postUpdateEvent);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ConfigurationUpdateEvent.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ConfigurationUpdateEvent.java
@@ -47,8 +47,12 @@ public class ConfigurationUpdateEvent implements EventStreamJsonMessage {
     return null;
   }
 
-  public ConfigurationUpdateEvent setComponentName(final String componentName) {
+  public void setComponentName(final String componentName) {
     this.componentName = Optional.ofNullable(componentName);
+  }
+
+  public ConfigurationUpdateEvent withComponentName(final String componentName) {
+    setComponentName(componentName);
     return this;
   }
 
@@ -59,8 +63,12 @@ public class ConfigurationUpdateEvent implements EventStreamJsonMessage {
     return null;
   }
 
-  public ConfigurationUpdateEvent setKeyPath(final List<String> keyPath) {
+  public void setKeyPath(final List<String> keyPath) {
     this.keyPath = Optional.ofNullable(keyPath);
+  }
+
+  public ConfigurationUpdateEvent withKeyPath(final List<String> keyPath) {
+    setKeyPath(keyPath);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ConfigurationUpdateEvents.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ConfigurationUpdateEvents.java
@@ -32,13 +32,17 @@ public class ConfigurationUpdateEvents implements EventStreamJsonMessage {
     return null;
   }
 
-  public ConfigurationUpdateEvents setConfigurationUpdateEvent(
-      final ConfigurationUpdateEvent configurationUpdateEvent) {
+  public void setConfigurationUpdateEvent(final ConfigurationUpdateEvent configurationUpdateEvent) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.configurationUpdateEvent = Optional.of(configurationUpdateEvent);
     this.setUnionMember = UnionMember.CONFIGURATION_UPDATE_EVENT;
+  }
+
+  public ConfigurationUpdateEvents withConfigurationUpdateEvent(
+      final ConfigurationUpdateEvent configurationUpdateEvent) {
+    setConfigurationUpdateEvent(configurationUpdateEvent);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ConfigurationValidityReport.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ConfigurationValidityReport.java
@@ -60,12 +60,21 @@ public class ConfigurationValidityReport implements EventStreamJsonMessage {
     return null;
   }
 
+  public void setStatus(final String status) {
+    this.status = Optional.ofNullable(status);
+  }
+
+  public ConfigurationValidityReport withStatus(final String status) {
+    setStatus(status);
+    return this;
+  }
+
   public void setStatus(final ConfigurationValidityStatus status) {
     this.status = Optional.ofNullable(status.getValue());
   }
 
-  public ConfigurationValidityReport setStatus(final String status) {
-    this.status = Optional.ofNullable(status);
+  public ConfigurationValidityReport withStatus(final ConfigurationValidityStatus status) {
+    setStatus(status);
     return this;
   }
 
@@ -76,8 +85,12 @@ public class ConfigurationValidityReport implements EventStreamJsonMessage {
     return null;
   }
 
-  public ConfigurationValidityReport setDeploymentId(final String deploymentId) {
+  public void setDeploymentId(final String deploymentId) {
     this.deploymentId = Optional.ofNullable(deploymentId);
+  }
+
+  public ConfigurationValidityReport withDeploymentId(final String deploymentId) {
+    setDeploymentId(deploymentId);
     return this;
   }
 
@@ -88,8 +101,12 @@ public class ConfigurationValidityReport implements EventStreamJsonMessage {
     return null;
   }
 
-  public ConfigurationValidityReport setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public ConfigurationValidityReport withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ConflictError.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ConflictError.java
@@ -50,8 +50,12 @@ public class ConflictError extends GreengrassCoreIPCError implements EventStream
     return null;
   }
 
-  public ConflictError setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public ConflictError withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/CreateDebugPasswordResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/CreateDebugPasswordResponse.java
@@ -68,8 +68,12 @@ public class CreateDebugPasswordResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateDebugPasswordResponse setPassword(final String password) {
+  public void setPassword(final String password) {
     this.password = Optional.ofNullable(password);
+  }
+
+  public CreateDebugPasswordResponse withPassword(final String password) {
+    setPassword(password);
     return this;
   }
 
@@ -80,8 +84,12 @@ public class CreateDebugPasswordResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateDebugPasswordResponse setUsername(final String username) {
+  public void setUsername(final String username) {
     this.username = Optional.ofNullable(username);
+  }
+
+  public CreateDebugPasswordResponse withUsername(final String username) {
+    setUsername(username);
     return this;
   }
 
@@ -92,8 +100,12 @@ public class CreateDebugPasswordResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateDebugPasswordResponse setPasswordExpiration(final Instant passwordExpiration) {
+  public void setPasswordExpiration(final Instant passwordExpiration) {
     this.passwordExpiration = Optional.ofNullable(passwordExpiration);
+  }
+
+  public CreateDebugPasswordResponse withPasswordExpiration(final Instant passwordExpiration) {
+    setPasswordExpiration(passwordExpiration);
     return this;
   }
 
@@ -104,8 +116,12 @@ public class CreateDebugPasswordResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateDebugPasswordResponse setCertificateSHA256Hash(final String certificateSHA256Hash) {
+  public void setCertificateSHA256Hash(final String certificateSHA256Hash) {
     this.certificateSHA256Hash = Optional.ofNullable(certificateSHA256Hash);
+  }
+
+  public CreateDebugPasswordResponse withCertificateSHA256Hash(final String certificateSHA256Hash) {
+    setCertificateSHA256Hash(certificateSHA256Hash);
     return this;
   }
 
@@ -116,8 +132,12 @@ public class CreateDebugPasswordResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateDebugPasswordResponse setCertificateSHA1Hash(final String certificateSHA1Hash) {
+  public void setCertificateSHA1Hash(final String certificateSHA1Hash) {
     this.certificateSHA1Hash = Optional.ofNullable(certificateSHA1Hash);
+  }
+
+  public CreateDebugPasswordResponse withCertificateSHA1Hash(final String certificateSHA1Hash) {
+    setCertificateSHA1Hash(certificateSHA1Hash);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/CreateLocalDeploymentRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/CreateLocalDeploymentRequest.java
@@ -83,8 +83,12 @@ public class CreateLocalDeploymentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateLocalDeploymentRequest setGroupName(final String groupName) {
+  public void setGroupName(final String groupName) {
     this.groupName = Optional.ofNullable(groupName);
+  }
+
+  public CreateLocalDeploymentRequest withGroupName(final String groupName) {
+    setGroupName(groupName);
     return this;
   }
 
@@ -95,9 +99,13 @@ public class CreateLocalDeploymentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateLocalDeploymentRequest setRootComponentVersionsToAdd(
-      final Map<String, String> rootComponentVersionsToAdd) {
+  public void setRootComponentVersionsToAdd(final Map<String, String> rootComponentVersionsToAdd) {
     this.rootComponentVersionsToAdd = Optional.ofNullable(rootComponentVersionsToAdd);
+  }
+
+  public CreateLocalDeploymentRequest withRootComponentVersionsToAdd(
+      final Map<String, String> rootComponentVersionsToAdd) {
+    setRootComponentVersionsToAdd(rootComponentVersionsToAdd);
     return this;
   }
 
@@ -108,9 +116,13 @@ public class CreateLocalDeploymentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateLocalDeploymentRequest setRootComponentsToRemove(
-      final List<String> rootComponentsToRemove) {
+  public void setRootComponentsToRemove(final List<String> rootComponentsToRemove) {
     this.rootComponentsToRemove = Optional.ofNullable(rootComponentsToRemove);
+  }
+
+  public CreateLocalDeploymentRequest withRootComponentsToRemove(
+      final List<String> rootComponentsToRemove) {
+    setRootComponentsToRemove(rootComponentsToRemove);
     return this;
   }
 
@@ -121,9 +133,14 @@ public class CreateLocalDeploymentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateLocalDeploymentRequest setComponentToConfiguration(
+  public void setComponentToConfiguration(
       final Map<String, Map<String, Object>> componentToConfiguration) {
     this.componentToConfiguration = Optional.ofNullable(componentToConfiguration);
+  }
+
+  public CreateLocalDeploymentRequest withComponentToConfiguration(
+      final Map<String, Map<String, Object>> componentToConfiguration) {
+    setComponentToConfiguration(componentToConfiguration);
     return this;
   }
 
@@ -134,9 +151,13 @@ public class CreateLocalDeploymentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateLocalDeploymentRequest setComponentToRunWithInfo(
-      final Map<String, RunWithInfo> componentToRunWithInfo) {
+  public void setComponentToRunWithInfo(final Map<String, RunWithInfo> componentToRunWithInfo) {
     this.componentToRunWithInfo = Optional.ofNullable(componentToRunWithInfo);
+  }
+
+  public CreateLocalDeploymentRequest withComponentToRunWithInfo(
+      final Map<String, RunWithInfo> componentToRunWithInfo) {
+    setComponentToRunWithInfo(componentToRunWithInfo);
     return this;
   }
 
@@ -147,8 +168,12 @@ public class CreateLocalDeploymentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateLocalDeploymentRequest setRecipeDirectoryPath(final String recipeDirectoryPath) {
+  public void setRecipeDirectoryPath(final String recipeDirectoryPath) {
     this.recipeDirectoryPath = Optional.ofNullable(recipeDirectoryPath);
+  }
+
+  public CreateLocalDeploymentRequest withRecipeDirectoryPath(final String recipeDirectoryPath) {
+    setRecipeDirectoryPath(recipeDirectoryPath);
     return this;
   }
 
@@ -159,9 +184,13 @@ public class CreateLocalDeploymentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateLocalDeploymentRequest setArtifactsDirectoryPath(
-      final String artifactsDirectoryPath) {
+  public void setArtifactsDirectoryPath(final String artifactsDirectoryPath) {
     this.artifactsDirectoryPath = Optional.ofNullable(artifactsDirectoryPath);
+  }
+
+  public CreateLocalDeploymentRequest withArtifactsDirectoryPath(
+      final String artifactsDirectoryPath) {
+    setArtifactsDirectoryPath(artifactsDirectoryPath);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/CreateLocalDeploymentResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/CreateLocalDeploymentResponse.java
@@ -39,8 +39,12 @@ public class CreateLocalDeploymentResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public CreateLocalDeploymentResponse setDeploymentId(final String deploymentId) {
+  public void setDeploymentId(final String deploymentId) {
     this.deploymentId = Optional.ofNullable(deploymentId);
+  }
+
+  public CreateLocalDeploymentResponse withDeploymentId(final String deploymentId) {
+    setDeploymentId(deploymentId);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/DeferComponentUpdateRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/DeferComponentUpdateRequest.java
@@ -54,8 +54,12 @@ public class DeferComponentUpdateRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public DeferComponentUpdateRequest setDeploymentId(final String deploymentId) {
+  public void setDeploymentId(final String deploymentId) {
     this.deploymentId = Optional.ofNullable(deploymentId);
+  }
+
+  public DeferComponentUpdateRequest withDeploymentId(final String deploymentId) {
+    setDeploymentId(deploymentId);
     return this;
   }
 
@@ -66,8 +70,12 @@ public class DeferComponentUpdateRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public DeferComponentUpdateRequest setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public DeferComponentUpdateRequest withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 
@@ -78,8 +86,12 @@ public class DeferComponentUpdateRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public DeferComponentUpdateRequest setRecheckAfterMs(final Long recheckAfterMs) {
+  public void setRecheckAfterMs(final Long recheckAfterMs) {
     this.recheckAfterMs = Optional.ofNullable(recheckAfterMs);
+  }
+
+  public DeferComponentUpdateRequest withRecheckAfterMs(final Long recheckAfterMs) {
+    setRecheckAfterMs(recheckAfterMs);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/DeleteThingShadowRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/DeleteThingShadowRequest.java
@@ -46,8 +46,12 @@ public class DeleteThingShadowRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public DeleteThingShadowRequest setThingName(final String thingName) {
+  public void setThingName(final String thingName) {
     this.thingName = Optional.ofNullable(thingName);
+  }
+
+  public DeleteThingShadowRequest withThingName(final String thingName) {
+    setThingName(thingName);
     return this;
   }
 
@@ -58,8 +62,12 @@ public class DeleteThingShadowRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public DeleteThingShadowRequest setShadowName(final String shadowName) {
+  public void setShadowName(final String shadowName) {
     this.shadowName = Optional.ofNullable(shadowName);
+  }
+
+  public DeleteThingShadowRequest withShadowName(final String shadowName) {
+    setShadowName(shadowName);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/DeleteThingShadowResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/DeleteThingShadowResponse.java
@@ -40,8 +40,12 @@ public class DeleteThingShadowResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public DeleteThingShadowResponse setPayload(final byte[] payload) {
+  public void setPayload(final byte[] payload) {
     this.payload = Optional.ofNullable(payload);
+  }
+
+  public DeleteThingShadowResponse withPayload(final byte[] payload) {
+    setPayload(payload);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/FailedUpdateConditionCheckError.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/FailedUpdateConditionCheckError.java
@@ -50,8 +50,12 @@ public class FailedUpdateConditionCheckError extends GreengrassCoreIPCError impl
     return null;
   }
 
-  public FailedUpdateConditionCheckError setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public FailedUpdateConditionCheckError withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetComponentDetailsRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetComponentDetailsRequest.java
@@ -39,8 +39,12 @@ public class GetComponentDetailsRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetComponentDetailsRequest setComponentName(final String componentName) {
+  public void setComponentName(final String componentName) {
     this.componentName = Optional.ofNullable(componentName);
+  }
+
+  public GetComponentDetailsRequest withComponentName(final String componentName) {
+    setComponentName(componentName);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetComponentDetailsResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetComponentDetailsResponse.java
@@ -39,8 +39,12 @@ public class GetComponentDetailsResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetComponentDetailsResponse setComponentDetails(final ComponentDetails componentDetails) {
+  public void setComponentDetails(final ComponentDetails componentDetails) {
     this.componentDetails = Optional.ofNullable(componentDetails);
+  }
+
+  public GetComponentDetailsResponse withComponentDetails(final ComponentDetails componentDetails) {
+    setComponentDetails(componentDetails);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetConfigurationRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetConfigurationRequest.java
@@ -47,8 +47,12 @@ public class GetConfigurationRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetConfigurationRequest setComponentName(final String componentName) {
+  public void setComponentName(final String componentName) {
     this.componentName = Optional.ofNullable(componentName);
+  }
+
+  public GetConfigurationRequest withComponentName(final String componentName) {
+    setComponentName(componentName);
     return this;
   }
 
@@ -59,8 +63,12 @@ public class GetConfigurationRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetConfigurationRequest setKeyPath(final List<String> keyPath) {
+  public void setKeyPath(final List<String> keyPath) {
     this.keyPath = Optional.ofNullable(keyPath);
+  }
+
+  public GetConfigurationRequest withKeyPath(final List<String> keyPath) {
+    setKeyPath(keyPath);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetConfigurationResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetConfigurationResponse.java
@@ -47,8 +47,12 @@ public class GetConfigurationResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetConfigurationResponse setComponentName(final String componentName) {
+  public void setComponentName(final String componentName) {
     this.componentName = Optional.ofNullable(componentName);
+  }
+
+  public GetConfigurationResponse withComponentName(final String componentName) {
+    setComponentName(componentName);
     return this;
   }
 
@@ -59,8 +63,12 @@ public class GetConfigurationResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetConfigurationResponse setValue(final Map<String, Object> value) {
+  public void setValue(final Map<String, Object> value) {
     this.value = Optional.ofNullable(value);
+  }
+
+  public GetConfigurationResponse withValue(final Map<String, Object> value) {
+    setValue(value);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetLocalDeploymentStatusRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetLocalDeploymentStatusRequest.java
@@ -39,8 +39,12 @@ public class GetLocalDeploymentStatusRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetLocalDeploymentStatusRequest setDeploymentId(final String deploymentId) {
+  public void setDeploymentId(final String deploymentId) {
     this.deploymentId = Optional.ofNullable(deploymentId);
+  }
+
+  public GetLocalDeploymentStatusRequest withDeploymentId(final String deploymentId) {
+    setDeploymentId(deploymentId);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetLocalDeploymentStatusResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetLocalDeploymentStatusResponse.java
@@ -39,8 +39,12 @@ public class GetLocalDeploymentStatusResponse implements EventStreamJsonMessage 
     return null;
   }
 
-  public GetLocalDeploymentStatusResponse setDeployment(final LocalDeployment deployment) {
+  public void setDeployment(final LocalDeployment deployment) {
     this.deployment = Optional.ofNullable(deployment);
+  }
+
+  public GetLocalDeploymentStatusResponse withDeployment(final LocalDeployment deployment) {
+    setDeployment(deployment);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetSecretValueRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetSecretValueRequest.java
@@ -53,8 +53,12 @@ public class GetSecretValueRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetSecretValueRequest setSecretId(final String secretId) {
+  public void setSecretId(final String secretId) {
     this.secretId = Optional.ofNullable(secretId);
+  }
+
+  public GetSecretValueRequest withSecretId(final String secretId) {
+    setSecretId(secretId);
     return this;
   }
 
@@ -65,8 +69,12 @@ public class GetSecretValueRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetSecretValueRequest setVersionId(final String versionId) {
+  public void setVersionId(final String versionId) {
     this.versionId = Optional.ofNullable(versionId);
+  }
+
+  public GetSecretValueRequest withVersionId(final String versionId) {
+    setVersionId(versionId);
     return this;
   }
 
@@ -77,8 +85,12 @@ public class GetSecretValueRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetSecretValueRequest setVersionStage(final String versionStage) {
+  public void setVersionStage(final String versionStage) {
     this.versionStage = Optional.ofNullable(versionStage);
+  }
+
+  public GetSecretValueRequest withVersionStage(final String versionStage) {
+    setVersionStage(versionStage);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetSecretValueResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetSecretValueResponse.java
@@ -61,8 +61,12 @@ public class GetSecretValueResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetSecretValueResponse setSecretId(final String secretId) {
+  public void setSecretId(final String secretId) {
     this.secretId = Optional.ofNullable(secretId);
+  }
+
+  public GetSecretValueResponse withSecretId(final String secretId) {
+    setSecretId(secretId);
     return this;
   }
 
@@ -73,8 +77,12 @@ public class GetSecretValueResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetSecretValueResponse setVersionId(final String versionId) {
+  public void setVersionId(final String versionId) {
     this.versionId = Optional.ofNullable(versionId);
+  }
+
+  public GetSecretValueResponse withVersionId(final String versionId) {
+    setVersionId(versionId);
     return this;
   }
 
@@ -85,8 +93,12 @@ public class GetSecretValueResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetSecretValueResponse setVersionStage(final List<String> versionStage) {
+  public void setVersionStage(final List<String> versionStage) {
     this.versionStage = Optional.ofNullable(versionStage);
+  }
+
+  public GetSecretValueResponse withVersionStage(final List<String> versionStage) {
+    setVersionStage(versionStage);
     return this;
   }
 
@@ -97,8 +109,12 @@ public class GetSecretValueResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetSecretValueResponse setSecretValue(final SecretValue secretValue) {
+  public void setSecretValue(final SecretValue secretValue) {
     this.secretValue = Optional.ofNullable(secretValue);
+  }
+
+  public GetSecretValueResponse withSecretValue(final SecretValue secretValue) {
+    setSecretValue(secretValue);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetThingShadowRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetThingShadowRequest.java
@@ -46,8 +46,12 @@ public class GetThingShadowRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetThingShadowRequest setThingName(final String thingName) {
+  public void setThingName(final String thingName) {
     this.thingName = Optional.ofNullable(thingName);
+  }
+
+  public GetThingShadowRequest withThingName(final String thingName) {
+    setThingName(thingName);
     return this;
   }
 
@@ -58,8 +62,12 @@ public class GetThingShadowRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetThingShadowRequest setShadowName(final String shadowName) {
+  public void setShadowName(final String shadowName) {
     this.shadowName = Optional.ofNullable(shadowName);
+  }
+
+  public GetThingShadowRequest withShadowName(final String shadowName) {
+    setShadowName(shadowName);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetThingShadowResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/GetThingShadowResponse.java
@@ -40,8 +40,12 @@ public class GetThingShadowResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public GetThingShadowResponse setPayload(final byte[] payload) {
+  public void setPayload(final byte[] payload) {
     this.payload = Optional.ofNullable(payload);
+  }
+
+  public GetThingShadowResponse withPayload(final byte[] payload) {
+    setPayload(payload);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/InvalidArgumentsError.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/InvalidArgumentsError.java
@@ -50,8 +50,12 @@ public class InvalidArgumentsError extends GreengrassCoreIPCError implements Eve
     return null;
   }
 
-  public InvalidArgumentsError setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public InvalidArgumentsError withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/InvalidArtifactsDirectoryPathError.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/InvalidArtifactsDirectoryPathError.java
@@ -50,8 +50,12 @@ public class InvalidArtifactsDirectoryPathError extends GreengrassCoreIPCError i
     return null;
   }
 
-  public InvalidArtifactsDirectoryPathError setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public InvalidArtifactsDirectoryPathError withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/InvalidRecipeDirectoryPathError.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/InvalidRecipeDirectoryPathError.java
@@ -50,8 +50,12 @@ public class InvalidRecipeDirectoryPathError extends GreengrassCoreIPCError impl
     return null;
   }
 
-  public InvalidRecipeDirectoryPathError setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public InvalidRecipeDirectoryPathError withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/InvalidTokenError.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/InvalidTokenError.java
@@ -50,8 +50,12 @@ public class InvalidTokenError extends GreengrassCoreIPCError implements EventSt
     return null;
   }
 
-  public InvalidTokenError setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public InvalidTokenError withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/IoTCoreMessage.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/IoTCoreMessage.java
@@ -32,12 +32,16 @@ public class IoTCoreMessage implements EventStreamJsonMessage {
     return null;
   }
 
-  public IoTCoreMessage setMessage(final MQTTMessage message) {
+  public void setMessage(final MQTTMessage message) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.message = Optional.of(message);
     this.setUnionMember = UnionMember.MESSAGE;
+  }
+
+  public IoTCoreMessage withMessage(final MQTTMessage message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/JsonMessage.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/JsonMessage.java
@@ -40,8 +40,12 @@ public class JsonMessage implements EventStreamJsonMessage {
     return null;
   }
 
-  public JsonMessage setMessage(final Map<String, Object> message) {
+  public void setMessage(final Map<String, Object> message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public JsonMessage withMessage(final Map<String, Object> message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ListComponentsResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ListComponentsResponse.java
@@ -40,8 +40,12 @@ public class ListComponentsResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public ListComponentsResponse setComponents(final List<ComponentDetails> components) {
+  public void setComponents(final List<ComponentDetails> components) {
     this.components = Optional.ofNullable(components);
+  }
+
+  public ListComponentsResponse withComponents(final List<ComponentDetails> components) {
+    setComponents(components);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ListLocalDeploymentsResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ListLocalDeploymentsResponse.java
@@ -40,9 +40,13 @@ public class ListLocalDeploymentsResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public ListLocalDeploymentsResponse setLocalDeployments(
-      final List<LocalDeployment> localDeployments) {
+  public void setLocalDeployments(final List<LocalDeployment> localDeployments) {
     this.localDeployments = Optional.ofNullable(localDeployments);
+  }
+
+  public ListLocalDeploymentsResponse withLocalDeployments(
+      final List<LocalDeployment> localDeployments) {
+    setLocalDeployments(localDeployments);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ListNamedShadowsForThingRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ListNamedShadowsForThingRequest.java
@@ -54,8 +54,12 @@ public class ListNamedShadowsForThingRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public ListNamedShadowsForThingRequest setThingName(final String thingName) {
+  public void setThingName(final String thingName) {
     this.thingName = Optional.ofNullable(thingName);
+  }
+
+  public ListNamedShadowsForThingRequest withThingName(final String thingName) {
+    setThingName(thingName);
     return this;
   }
 
@@ -66,8 +70,12 @@ public class ListNamedShadowsForThingRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public ListNamedShadowsForThingRequest setNextToken(final String nextToken) {
+  public void setNextToken(final String nextToken) {
     this.nextToken = Optional.ofNullable(nextToken);
+  }
+
+  public ListNamedShadowsForThingRequest withNextToken(final String nextToken) {
+    setNextToken(nextToken);
     return this;
   }
 
@@ -78,8 +86,12 @@ public class ListNamedShadowsForThingRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public ListNamedShadowsForThingRequest setPageSize(final Integer pageSize) {
+  public void setPageSize(final Integer pageSize) {
     this.pageSize = Optional.ofNullable(pageSize);
+  }
+
+  public ListNamedShadowsForThingRequest withPageSize(final Integer pageSize) {
+    setPageSize(pageSize);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ListNamedShadowsForThingResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ListNamedShadowsForThingResponse.java
@@ -55,8 +55,12 @@ public class ListNamedShadowsForThingResponse implements EventStreamJsonMessage 
     return null;
   }
 
-  public ListNamedShadowsForThingResponse setResults(final List<String> results) {
+  public void setResults(final List<String> results) {
     this.results = Optional.ofNullable(results);
+  }
+
+  public ListNamedShadowsForThingResponse withResults(final List<String> results) {
+    setResults(results);
     return this;
   }
 
@@ -67,8 +71,12 @@ public class ListNamedShadowsForThingResponse implements EventStreamJsonMessage 
     return null;
   }
 
-  public ListNamedShadowsForThingResponse setTimestamp(final Instant timestamp) {
+  public void setTimestamp(final Instant timestamp) {
     this.timestamp = Optional.ofNullable(timestamp);
+  }
+
+  public ListNamedShadowsForThingResponse withTimestamp(final Instant timestamp) {
+    setTimestamp(timestamp);
     return this;
   }
 
@@ -79,8 +87,12 @@ public class ListNamedShadowsForThingResponse implements EventStreamJsonMessage 
     return null;
   }
 
-  public ListNamedShadowsForThingResponse setNextToken(final String nextToken) {
+  public void setNextToken(final String nextToken) {
     this.nextToken = Optional.ofNullable(nextToken);
+  }
+
+  public ListNamedShadowsForThingResponse withNextToken(final String nextToken) {
+    setNextToken(nextToken);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/LocalDeployment.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/LocalDeployment.java
@@ -46,8 +46,12 @@ public class LocalDeployment implements EventStreamJsonMessage {
     return null;
   }
 
-  public LocalDeployment setDeploymentId(final String deploymentId) {
+  public void setDeploymentId(final String deploymentId) {
     this.deploymentId = Optional.ofNullable(deploymentId);
+  }
+
+  public LocalDeployment withDeploymentId(final String deploymentId) {
+    setDeploymentId(deploymentId);
     return this;
   }
 
@@ -65,12 +69,21 @@ public class LocalDeployment implements EventStreamJsonMessage {
     return null;
   }
 
+  public void setStatus(final String status) {
+    this.status = Optional.ofNullable(status);
+  }
+
+  public LocalDeployment withStatus(final String status) {
+    setStatus(status);
+    return this;
+  }
+
   public void setStatus(final DeploymentStatus status) {
     this.status = Optional.ofNullable(status.getValue());
   }
 
-  public LocalDeployment setStatus(final String status) {
-    this.status = Optional.ofNullable(status);
+  public LocalDeployment withStatus(final DeploymentStatus status) {
+    setStatus(status);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/MQTTMessage.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/MQTTMessage.java
@@ -47,8 +47,12 @@ public class MQTTMessage implements EventStreamJsonMessage {
     return null;
   }
 
-  public MQTTMessage setTopicName(final String topicName) {
+  public void setTopicName(final String topicName) {
     this.topicName = Optional.ofNullable(topicName);
+  }
+
+  public MQTTMessage withTopicName(final String topicName) {
+    setTopicName(topicName);
     return this;
   }
 
@@ -59,8 +63,12 @@ public class MQTTMessage implements EventStreamJsonMessage {
     return null;
   }
 
-  public MQTTMessage setPayload(final byte[] payload) {
+  public void setPayload(final byte[] payload) {
     this.payload = Optional.ofNullable(payload);
+  }
+
+  public MQTTMessage withPayload(final byte[] payload) {
+    setPayload(payload);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PauseComponentRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PauseComponentRequest.java
@@ -39,8 +39,12 @@ public class PauseComponentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public PauseComponentRequest setComponentName(final String componentName) {
+  public void setComponentName(final String componentName) {
     this.componentName = Optional.ofNullable(componentName);
+  }
+
+  public PauseComponentRequest withComponentName(final String componentName) {
+    setComponentName(componentName);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PostComponentUpdateEvent.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PostComponentUpdateEvent.java
@@ -39,8 +39,12 @@ public class PostComponentUpdateEvent implements EventStreamJsonMessage {
     return null;
   }
 
-  public PostComponentUpdateEvent setDeploymentId(final String deploymentId) {
+  public void setDeploymentId(final String deploymentId) {
     this.deploymentId = Optional.ofNullable(deploymentId);
+  }
+
+  public PostComponentUpdateEvent withDeploymentId(final String deploymentId) {
+    setDeploymentId(deploymentId);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PreComponentUpdateEvent.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PreComponentUpdateEvent.java
@@ -47,8 +47,12 @@ public class PreComponentUpdateEvent implements EventStreamJsonMessage {
     return null;
   }
 
-  public PreComponentUpdateEvent setDeploymentId(final String deploymentId) {
+  public void setDeploymentId(final String deploymentId) {
     this.deploymentId = Optional.ofNullable(deploymentId);
+  }
+
+  public PreComponentUpdateEvent withDeploymentId(final String deploymentId) {
+    setDeploymentId(deploymentId);
     return this;
   }
 
@@ -59,8 +63,12 @@ public class PreComponentUpdateEvent implements EventStreamJsonMessage {
     return null;
   }
 
-  public PreComponentUpdateEvent setIsGgcRestarting(final Boolean isGgcRestarting) {
+  public void setIsGgcRestarting(final Boolean isGgcRestarting) {
     this.isGgcRestarting = Optional.ofNullable(isGgcRestarting);
+  }
+
+  public PreComponentUpdateEvent withIsGgcRestarting(final Boolean isGgcRestarting) {
+    setIsGgcRestarting(isGgcRestarting);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PublishMessage.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PublishMessage.java
@@ -39,12 +39,16 @@ public class PublishMessage implements EventStreamJsonMessage {
     return null;
   }
 
-  public PublishMessage setJsonMessage(final JsonMessage jsonMessage) {
+  public void setJsonMessage(final JsonMessage jsonMessage) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.jsonMessage = Optional.of(jsonMessage);
     this.setUnionMember = UnionMember.JSON_MESSAGE;
+  }
+
+  public PublishMessage withJsonMessage(final JsonMessage jsonMessage) {
+    setJsonMessage(jsonMessage);
     return this;
   }
 
@@ -55,12 +59,16 @@ public class PublishMessage implements EventStreamJsonMessage {
     return null;
   }
 
-  public PublishMessage setBinaryMessage(final BinaryMessage binaryMessage) {
+  public void setBinaryMessage(final BinaryMessage binaryMessage) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.binaryMessage = Optional.of(binaryMessage);
     this.setUnionMember = UnionMember.BINARY_MESSAGE;
+  }
+
+  public PublishMessage withBinaryMessage(final BinaryMessage binaryMessage) {
+    setBinaryMessage(binaryMessage);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PublishToIoTCoreRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PublishToIoTCoreRequest.java
@@ -54,8 +54,12 @@ public class PublishToIoTCoreRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public PublishToIoTCoreRequest setTopicName(final String topicName) {
+  public void setTopicName(final String topicName) {
     this.topicName = Optional.ofNullable(topicName);
+  }
+
+  public PublishToIoTCoreRequest withTopicName(final String topicName) {
+    setTopicName(topicName);
     return this;
   }
 
@@ -73,12 +77,21 @@ public class PublishToIoTCoreRequest implements EventStreamJsonMessage {
     return null;
   }
 
+  public void setQos(final String qos) {
+    this.qos = Optional.ofNullable(qos);
+  }
+
+  public PublishToIoTCoreRequest withQos(final String qos) {
+    setQos(qos);
+    return this;
+  }
+
   public void setQos(final QOS qos) {
     this.qos = Optional.ofNullable(qos.getValue());
   }
 
-  public PublishToIoTCoreRequest setQos(final String qos) {
-    this.qos = Optional.ofNullable(qos);
+  public PublishToIoTCoreRequest withQos(final QOS qos) {
+    setQos(qos);
     return this;
   }
 
@@ -89,8 +102,12 @@ public class PublishToIoTCoreRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public PublishToIoTCoreRequest setPayload(final byte[] payload) {
+  public void setPayload(final byte[] payload) {
     this.payload = Optional.ofNullable(payload);
+  }
+
+  public PublishToIoTCoreRequest withPayload(final byte[] payload) {
+    setPayload(payload);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PublishToTopicRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/PublishToTopicRequest.java
@@ -46,8 +46,12 @@ public class PublishToTopicRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public PublishToTopicRequest setTopic(final String topic) {
+  public void setTopic(final String topic) {
     this.topic = Optional.ofNullable(topic);
+  }
+
+  public PublishToTopicRequest withTopic(final String topic) {
+    setTopic(topic);
     return this;
   }
 
@@ -58,8 +62,12 @@ public class PublishToTopicRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public PublishToTopicRequest setPublishMessage(final PublishMessage publishMessage) {
+  public void setPublishMessage(final PublishMessage publishMessage) {
     this.publishMessage = Optional.ofNullable(publishMessage);
+  }
+
+  public PublishToTopicRequest withPublishMessage(final PublishMessage publishMessage) {
+    setPublishMessage(publishMessage);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ResourceNotFoundError.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ResourceNotFoundError.java
@@ -66,8 +66,12 @@ public class ResourceNotFoundError extends GreengrassCoreIPCError implements Eve
     return null;
   }
 
-  public ResourceNotFoundError setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public ResourceNotFoundError withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 
@@ -78,8 +82,12 @@ public class ResourceNotFoundError extends GreengrassCoreIPCError implements Eve
     return null;
   }
 
-  public ResourceNotFoundError setResourceType(final String resourceType) {
+  public void setResourceType(final String resourceType) {
     this.resourceType = Optional.ofNullable(resourceType);
+  }
+
+  public ResourceNotFoundError withResourceType(final String resourceType) {
+    setResourceType(resourceType);
     return this;
   }
 
@@ -90,8 +98,12 @@ public class ResourceNotFoundError extends GreengrassCoreIPCError implements Eve
     return null;
   }
 
-  public ResourceNotFoundError setResourceName(final String resourceName) {
+  public void setResourceName(final String resourceName) {
     this.resourceName = Optional.ofNullable(resourceName);
+  }
+
+  public ResourceNotFoundError withResourceName(final String resourceName) {
+    setResourceName(resourceName);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/RestartComponentRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/RestartComponentRequest.java
@@ -39,8 +39,12 @@ public class RestartComponentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public RestartComponentRequest setComponentName(final String componentName) {
+  public void setComponentName(final String componentName) {
     this.componentName = Optional.ofNullable(componentName);
+  }
+
+  public RestartComponentRequest withComponentName(final String componentName) {
+    setComponentName(componentName);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/RestartComponentResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/RestartComponentResponse.java
@@ -53,12 +53,21 @@ public class RestartComponentResponse implements EventStreamJsonMessage {
     return null;
   }
 
+  public void setRestartStatus(final String restartStatus) {
+    this.restartStatus = Optional.ofNullable(restartStatus);
+  }
+
+  public RestartComponentResponse withRestartStatus(final String restartStatus) {
+    setRestartStatus(restartStatus);
+    return this;
+  }
+
   public void setRestartStatus(final RequestStatus restartStatus) {
     this.restartStatus = Optional.ofNullable(restartStatus.getValue());
   }
 
-  public RestartComponentResponse setRestartStatus(final String restartStatus) {
-    this.restartStatus = Optional.ofNullable(restartStatus);
+  public RestartComponentResponse withRestartStatus(final RequestStatus restartStatus) {
+    setRestartStatus(restartStatus);
     return this;
   }
 
@@ -69,8 +78,12 @@ public class RestartComponentResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public RestartComponentResponse setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public RestartComponentResponse withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ResumeComponentRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ResumeComponentRequest.java
@@ -39,8 +39,12 @@ public class ResumeComponentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public ResumeComponentRequest setComponentName(final String componentName) {
+  public void setComponentName(final String componentName) {
     this.componentName = Optional.ofNullable(componentName);
+  }
+
+  public ResumeComponentRequest withComponentName(final String componentName) {
+    setComponentName(componentName);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/RunWithInfo.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/RunWithInfo.java
@@ -53,8 +53,12 @@ public class RunWithInfo implements EventStreamJsonMessage {
     return null;
   }
 
-  public RunWithInfo setPosixUser(final String posixUser) {
+  public void setPosixUser(final String posixUser) {
     this.posixUser = Optional.ofNullable(posixUser);
+  }
+
+  public RunWithInfo withPosixUser(final String posixUser) {
+    setPosixUser(posixUser);
     return this;
   }
 
@@ -65,8 +69,12 @@ public class RunWithInfo implements EventStreamJsonMessage {
     return null;
   }
 
-  public RunWithInfo setWindowsUser(final String windowsUser) {
+  public void setWindowsUser(final String windowsUser) {
     this.windowsUser = Optional.ofNullable(windowsUser);
+  }
+
+  public RunWithInfo withWindowsUser(final String windowsUser) {
+    setWindowsUser(windowsUser);
     return this;
   }
 
@@ -77,8 +85,12 @@ public class RunWithInfo implements EventStreamJsonMessage {
     return null;
   }
 
-  public RunWithInfo setSystemResourceLimits(final SystemResourceLimits systemResourceLimits) {
+  public void setSystemResourceLimits(final SystemResourceLimits systemResourceLimits) {
     this.systemResourceLimits = Optional.ofNullable(systemResourceLimits);
+  }
+
+  public RunWithInfo withSystemResourceLimits(final SystemResourceLimits systemResourceLimits) {
+    setSystemResourceLimits(systemResourceLimits);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SecretValue.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SecretValue.java
@@ -40,12 +40,16 @@ public class SecretValue implements EventStreamJsonMessage {
     return null;
   }
 
-  public SecretValue setSecretString(final String secretString) {
+  public void setSecretString(final String secretString) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.secretString = Optional.of(secretString);
     this.setUnionMember = UnionMember.SECRET_STRING;
+  }
+
+  public SecretValue withSecretString(final String secretString) {
+    setSecretString(secretString);
     return this;
   }
 
@@ -56,12 +60,16 @@ public class SecretValue implements EventStreamJsonMessage {
     return null;
   }
 
-  public SecretValue setSecretBinary(final byte[] secretBinary) {
+  public void setSecretBinary(final byte[] secretBinary) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.secretBinary = Optional.of(secretBinary);
     this.setUnionMember = UnionMember.SECRET_BINARY;
+  }
+
+  public SecretValue withSecretBinary(final byte[] secretBinary) {
+    setSecretBinary(secretBinary);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SendConfigurationValidityReportRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SendConfigurationValidityReportRequest.java
@@ -39,9 +39,14 @@ public class SendConfigurationValidityReportRequest implements EventStreamJsonMe
     return null;
   }
 
-  public SendConfigurationValidityReportRequest setConfigurationValidityReport(
+  public void setConfigurationValidityReport(
       final ConfigurationValidityReport configurationValidityReport) {
     this.configurationValidityReport = Optional.ofNullable(configurationValidityReport);
+  }
+
+  public SendConfigurationValidityReportRequest withConfigurationValidityReport(
+      final ConfigurationValidityReport configurationValidityReport) {
+    setConfigurationValidityReport(configurationValidityReport);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ServiceError.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ServiceError.java
@@ -50,8 +50,12 @@ public class ServiceError extends GreengrassCoreIPCError implements EventStreamJ
     return null;
   }
 
-  public ServiceError setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public ServiceError withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/StopComponentRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/StopComponentRequest.java
@@ -39,8 +39,12 @@ public class StopComponentRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public StopComponentRequest setComponentName(final String componentName) {
+  public void setComponentName(final String componentName) {
     this.componentName = Optional.ofNullable(componentName);
+  }
+
+  public StopComponentRequest withComponentName(final String componentName) {
+    setComponentName(componentName);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/StopComponentResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/StopComponentResponse.java
@@ -53,12 +53,21 @@ public class StopComponentResponse implements EventStreamJsonMessage {
     return null;
   }
 
+  public void setStopStatus(final String stopStatus) {
+    this.stopStatus = Optional.ofNullable(stopStatus);
+  }
+
+  public StopComponentResponse withStopStatus(final String stopStatus) {
+    setStopStatus(stopStatus);
+    return this;
+  }
+
   public void setStopStatus(final RequestStatus stopStatus) {
     this.stopStatus = Optional.ofNullable(stopStatus.getValue());
   }
 
-  public StopComponentResponse setStopStatus(final String stopStatus) {
-    this.stopStatus = Optional.ofNullable(stopStatus);
+  public StopComponentResponse withStopStatus(final RequestStatus stopStatus) {
+    setStopStatus(stopStatus);
     return this;
   }
 
@@ -69,8 +78,12 @@ public class StopComponentResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public StopComponentResponse setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public StopComponentResponse withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SubscribeToConfigurationUpdateRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SubscribeToConfigurationUpdateRequest.java
@@ -47,8 +47,12 @@ public class SubscribeToConfigurationUpdateRequest implements EventStreamJsonMes
     return null;
   }
 
-  public SubscribeToConfigurationUpdateRequest setComponentName(final String componentName) {
+  public void setComponentName(final String componentName) {
     this.componentName = Optional.ofNullable(componentName);
+  }
+
+  public SubscribeToConfigurationUpdateRequest withComponentName(final String componentName) {
+    setComponentName(componentName);
     return this;
   }
 
@@ -59,8 +63,12 @@ public class SubscribeToConfigurationUpdateRequest implements EventStreamJsonMes
     return null;
   }
 
-  public SubscribeToConfigurationUpdateRequest setKeyPath(final List<String> keyPath) {
+  public void setKeyPath(final List<String> keyPath) {
     this.keyPath = Optional.ofNullable(keyPath);
+  }
+
+  public SubscribeToConfigurationUpdateRequest withKeyPath(final List<String> keyPath) {
+    setKeyPath(keyPath);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SubscribeToIoTCoreRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SubscribeToIoTCoreRequest.java
@@ -46,8 +46,12 @@ public class SubscribeToIoTCoreRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public SubscribeToIoTCoreRequest setTopicName(final String topicName) {
+  public void setTopicName(final String topicName) {
     this.topicName = Optional.ofNullable(topicName);
+  }
+
+  public SubscribeToIoTCoreRequest withTopicName(final String topicName) {
+    setTopicName(topicName);
     return this;
   }
 
@@ -65,12 +69,21 @@ public class SubscribeToIoTCoreRequest implements EventStreamJsonMessage {
     return null;
   }
 
+  public void setQos(final String qos) {
+    this.qos = Optional.ofNullable(qos);
+  }
+
+  public SubscribeToIoTCoreRequest withQos(final String qos) {
+    setQos(qos);
+    return this;
+  }
+
   public void setQos(final QOS qos) {
     this.qos = Optional.ofNullable(qos.getValue());
   }
 
-  public SubscribeToIoTCoreRequest setQos(final String qos) {
-    this.qos = Optional.ofNullable(qos);
+  public SubscribeToIoTCoreRequest withQos(final QOS qos) {
+    setQos(qos);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SubscribeToTopicRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SubscribeToTopicRequest.java
@@ -39,8 +39,12 @@ public class SubscribeToTopicRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public SubscribeToTopicRequest setTopic(final String topic) {
+  public void setTopic(final String topic) {
     this.topic = Optional.ofNullable(topic);
+  }
+
+  public SubscribeToTopicRequest withTopic(final String topic) {
+    setTopic(topic);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SubscribeToTopicResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SubscribeToTopicResponse.java
@@ -39,8 +39,12 @@ public class SubscribeToTopicResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public SubscribeToTopicResponse setTopicName(final String topicName) {
+  public void setTopicName(final String topicName) {
     this.topicName = Optional.ofNullable(topicName);
+  }
+
+  public SubscribeToTopicResponse withTopicName(final String topicName) {
+    setTopicName(topicName);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SubscriptionResponseMessage.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SubscriptionResponseMessage.java
@@ -39,12 +39,16 @@ public class SubscriptionResponseMessage implements EventStreamJsonMessage {
     return null;
   }
 
-  public SubscriptionResponseMessage setJsonMessage(final JsonMessage jsonMessage) {
+  public void setJsonMessage(final JsonMessage jsonMessage) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.jsonMessage = Optional.of(jsonMessage);
     this.setUnionMember = UnionMember.JSON_MESSAGE;
+  }
+
+  public SubscriptionResponseMessage withJsonMessage(final JsonMessage jsonMessage) {
+    setJsonMessage(jsonMessage);
     return this;
   }
 
@@ -55,12 +59,16 @@ public class SubscriptionResponseMessage implements EventStreamJsonMessage {
     return null;
   }
 
-  public SubscriptionResponseMessage setBinaryMessage(final BinaryMessage binaryMessage) {
+  public void setBinaryMessage(final BinaryMessage binaryMessage) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.binaryMessage = Optional.of(binaryMessage);
     this.setUnionMember = UnionMember.BINARY_MESSAGE;
+  }
+
+  public SubscriptionResponseMessage withBinaryMessage(final BinaryMessage binaryMessage) {
+    setBinaryMessage(binaryMessage);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SystemResourceLimits.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/SystemResourceLimits.java
@@ -48,8 +48,12 @@ public class SystemResourceLimits implements EventStreamJsonMessage {
     return null;
   }
 
-  public SystemResourceLimits setMemory(final Long memory) {
+  public void setMemory(final Long memory) {
     this.memory = Optional.ofNullable(memory);
+  }
+
+  public SystemResourceLimits withMemory(final Long memory) {
+    setMemory(memory);
     return this;
   }
 
@@ -60,8 +64,12 @@ public class SystemResourceLimits implements EventStreamJsonMessage {
     return null;
   }
 
-  public SystemResourceLimits setCpus(final Double cpus) {
+  public void setCpus(final Double cpus) {
     this.cpus = Optional.ofNullable(cpus);
+  }
+
+  public SystemResourceLimits withCpus(final Double cpus) {
+    setCpus(cpus);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/UnauthorizedError.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/UnauthorizedError.java
@@ -50,8 +50,12 @@ public class UnauthorizedError extends GreengrassCoreIPCError implements EventSt
     return null;
   }
 
-  public UnauthorizedError setMessage(final String message) {
+  public void setMessage(final String message) {
     this.message = Optional.ofNullable(message);
+  }
+
+  public UnauthorizedError withMessage(final String message) {
+    setMessage(message);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/UpdateConfigurationRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/UpdateConfigurationRequest.java
@@ -56,8 +56,12 @@ public class UpdateConfigurationRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public UpdateConfigurationRequest setKeyPath(final List<String> keyPath) {
+  public void setKeyPath(final List<String> keyPath) {
     this.keyPath = Optional.ofNullable(keyPath);
+  }
+
+  public UpdateConfigurationRequest withKeyPath(final List<String> keyPath) {
+    setKeyPath(keyPath);
     return this;
   }
 
@@ -68,8 +72,12 @@ public class UpdateConfigurationRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public UpdateConfigurationRequest setTimestamp(final Instant timestamp) {
+  public void setTimestamp(final Instant timestamp) {
     this.timestamp = Optional.ofNullable(timestamp);
+  }
+
+  public UpdateConfigurationRequest withTimestamp(final Instant timestamp) {
+    setTimestamp(timestamp);
     return this;
   }
 
@@ -80,8 +88,12 @@ public class UpdateConfigurationRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public UpdateConfigurationRequest setValueToMerge(final Map<String, Object> valueToMerge) {
+  public void setValueToMerge(final Map<String, Object> valueToMerge) {
     this.valueToMerge = Optional.ofNullable(valueToMerge);
+  }
+
+  public UpdateConfigurationRequest withValueToMerge(final Map<String, Object> valueToMerge) {
+    setValueToMerge(valueToMerge);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/UpdateStateRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/UpdateStateRequest.java
@@ -46,12 +46,21 @@ public class UpdateStateRequest implements EventStreamJsonMessage {
     return null;
   }
 
+  public void setState(final String state) {
+    this.state = Optional.ofNullable(state);
+  }
+
+  public UpdateStateRequest withState(final String state) {
+    setState(state);
+    return this;
+  }
+
   public void setState(final ReportedLifecycleState state) {
     this.state = Optional.ofNullable(state.getValue());
   }
 
-  public UpdateStateRequest setState(final String state) {
-    this.state = Optional.ofNullable(state);
+  public UpdateStateRequest withState(final ReportedLifecycleState state) {
+    setState(state);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/UpdateThingShadowRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/UpdateThingShadowRequest.java
@@ -54,8 +54,12 @@ public class UpdateThingShadowRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public UpdateThingShadowRequest setThingName(final String thingName) {
+  public void setThingName(final String thingName) {
     this.thingName = Optional.ofNullable(thingName);
+  }
+
+  public UpdateThingShadowRequest withThingName(final String thingName) {
+    setThingName(thingName);
     return this;
   }
 
@@ -66,8 +70,12 @@ public class UpdateThingShadowRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public UpdateThingShadowRequest setShadowName(final String shadowName) {
+  public void setShadowName(final String shadowName) {
     this.shadowName = Optional.ofNullable(shadowName);
+  }
+
+  public UpdateThingShadowRequest withShadowName(final String shadowName) {
+    setShadowName(shadowName);
     return this;
   }
 
@@ -78,8 +86,12 @@ public class UpdateThingShadowRequest implements EventStreamJsonMessage {
     return null;
   }
 
-  public UpdateThingShadowRequest setPayload(final byte[] payload) {
+  public void setPayload(final byte[] payload) {
     this.payload = Optional.ofNullable(payload);
+  }
+
+  public UpdateThingShadowRequest withPayload(final byte[] payload) {
+    setPayload(payload);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/UpdateThingShadowResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/UpdateThingShadowResponse.java
@@ -40,8 +40,12 @@ public class UpdateThingShadowResponse implements EventStreamJsonMessage {
     return null;
   }
 
-  public UpdateThingShadowResponse setPayload(final byte[] payload) {
+  public void setPayload(final byte[] payload) {
     this.payload = Optional.ofNullable(payload);
+  }
+
+  public UpdateThingShadowResponse withPayload(final byte[] payload) {
+    setPayload(payload);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ValidateAuthorizationTokenRequest.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ValidateAuthorizationTokenRequest.java
@@ -39,8 +39,12 @@ public class ValidateAuthorizationTokenRequest implements EventStreamJsonMessage
     return null;
   }
 
-  public ValidateAuthorizationTokenRequest setToken(final String token) {
+  public void setToken(final String token) {
     this.token = Optional.ofNullable(token);
+  }
+
+  public ValidateAuthorizationTokenRequest withToken(final String token) {
+    setToken(token);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ValidateAuthorizationTokenResponse.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ValidateAuthorizationTokenResponse.java
@@ -40,8 +40,12 @@ public class ValidateAuthorizationTokenResponse implements EventStreamJsonMessag
     return null;
   }
 
-  public ValidateAuthorizationTokenResponse setIsValid(final Boolean isValid) {
+  public void setIsValid(final Boolean isValid) {
     this.isValid = Optional.ofNullable(isValid);
+  }
+
+  public ValidateAuthorizationTokenResponse withIsValid(final Boolean isValid) {
+    setIsValid(isValid);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ValidateConfigurationUpdateEvent.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ValidateConfigurationUpdateEvent.java
@@ -47,9 +47,13 @@ public class ValidateConfigurationUpdateEvent implements EventStreamJsonMessage 
     return null;
   }
 
-  public ValidateConfigurationUpdateEvent setConfiguration(
-      final Map<String, Object> configuration) {
+  public void setConfiguration(final Map<String, Object> configuration) {
     this.configuration = Optional.ofNullable(configuration);
+  }
+
+  public ValidateConfigurationUpdateEvent withConfiguration(
+      final Map<String, Object> configuration) {
+    setConfiguration(configuration);
     return this;
   }
 
@@ -60,8 +64,12 @@ public class ValidateConfigurationUpdateEvent implements EventStreamJsonMessage 
     return null;
   }
 
-  public ValidateConfigurationUpdateEvent setDeploymentId(final String deploymentId) {
+  public void setDeploymentId(final String deploymentId) {
     this.deploymentId = Optional.ofNullable(deploymentId);
+  }
+
+  public ValidateConfigurationUpdateEvent withDeploymentId(final String deploymentId) {
+    setDeploymentId(deploymentId);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ValidateConfigurationUpdateEvents.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/model/software/amazon/awssdk/aws/greengrass/model/ValidateConfigurationUpdateEvents.java
@@ -32,13 +32,18 @@ public class ValidateConfigurationUpdateEvents implements EventStreamJsonMessage
     return null;
   }
 
-  public ValidateConfigurationUpdateEvents setValidateConfigurationUpdateEvent(
+  public void setValidateConfigurationUpdateEvent(
       final ValidateConfigurationUpdateEvent validateConfigurationUpdateEvent) {
     if (setUnionMember != null) {
       setUnionMember.nullify(this);
     }
     this.validateConfigurationUpdateEvent = Optional.of(validateConfigurationUpdateEvent);
     this.setUnionMember = UnionMember.VALIDATE_CONFIGURATION_UPDATE_EVENT;
+  }
+
+  public ValidateConfigurationUpdateEvents withValidateConfigurationUpdateEvent(
+      final ValidateConfigurationUpdateEvent validateConfigurationUpdateEvent) {
+    setValidateConfigurationUpdateEvent(validateConfigurationUpdateEvent);
     return this;
   }
 

--- a/sdk/greengrass/greengrass-client/src/test/java/GreengrassV2ClientTest.java
+++ b/sdk/greengrass/greengrass-client/src/test/java/GreengrassV2ClientTest.java
@@ -63,7 +63,7 @@ public class GreengrassV2ClientTest {
 
                 @Override
                 public CreateLocalDeploymentResponse handleRequest(CreateLocalDeploymentRequest request) {
-                    return new CreateLocalDeploymentResponse().setDeploymentId("deployment");
+                    return new CreateLocalDeploymentResponse().withDeploymentId("deployment");
                 }
 
                 @Override
@@ -79,10 +79,10 @@ public class GreengrassV2ClientTest {
                 @Override
                 public SubscribeToTopicResponse handleRequest(SubscribeToTopicRequest request) {
                     new Thread(() -> {
-                        sendStreamEvent(new SubscriptionResponseMessage().setBinaryMessage(
-                                new BinaryMessage().setMessage("message".getBytes(StandardCharsets.UTF_8))));
+                        sendStreamEvent(new SubscriptionResponseMessage().withBinaryMessage(
+                                new BinaryMessage().withMessage("message".getBytes(StandardCharsets.UTF_8))));
                     }).start();
-                    return new SubscribeToTopicResponse().setTopicName(request.getTopic());
+                    return new SubscribeToTopicResponse().withTopicName(request.getTopic());
                 }
 
                 @Override
@@ -126,7 +126,7 @@ public class GreengrassV2ClientTest {
         CompletableFuture<String> receivedMessage = new CompletableFuture<>();
         CompletableFuture<String> finalReceivedMessage = receivedMessage;
         GreengrassCoreIPCClientV2.StreamingResponse<SubscribeToTopicResponse, SubscribeToTopicResponseHandler> subResp =
-                client.subscribeToTopic(new SubscribeToTopicRequest().setTopic("abc"), (x) -> {
+                client.subscribeToTopic(new SubscribeToTopicRequest().withTopic("abc"), (x) -> {
                     if (!Thread.currentThread().getName().contains("pool")) {
                         System.out.println(Thread.currentThread().getName());
                         finalReceivedMessage.completeExceptionally(
@@ -142,7 +142,8 @@ public class GreengrassV2ClientTest {
         subscriptionClosed = new CompletableFuture<>();
         receivedMessage = new CompletableFuture<>();
         CompletableFuture<String> finalReceivedMessage1 = receivedMessage;
-        subResp = client.subscribeToTopic(new SubscribeToTopicRequest().setTopic("abc"), new StreamResponseHandler<SubscriptionResponseMessage>() {
+        subResp = client.subscribeToTopic(new SubscribeToTopicRequest().withTopic("abc"),
+                new StreamResponseHandler<SubscriptionResponseMessage>() {
             @Override
             public void onStreamEvent(SubscriptionResponseMessage streamEvent) {
                 if (!Thread.currentThread().getName().contains("pool")) {
@@ -170,7 +171,7 @@ public class GreengrassV2ClientTest {
         receivedMessage = new CompletableFuture<>();
         CompletableFuture<String> finalReceivedMessage2 = receivedMessage;
         GreengrassCoreIPCClientV2.StreamingResponse<CompletableFuture<SubscribeToTopicResponse>, SubscribeToTopicResponseHandler>
-                subRespAsync = client.subscribeToTopicAsync(new SubscribeToTopicRequest().setTopic("abc"),
+                subRespAsync = client.subscribeToTopicAsync(new SubscribeToTopicRequest().withTopic("abc"),
                 new StreamResponseHandler<SubscriptionResponseMessage>() {
                     @Override
                     public void onStreamEvent(SubscriptionResponseMessage streamEvent) {
@@ -198,7 +199,7 @@ public class GreengrassV2ClientTest {
         subscriptionClosed = new CompletableFuture<>();
         receivedMessage = new CompletableFuture<>();
         CompletableFuture<String> finalReceivedMessage3 = receivedMessage;
-        subRespAsync = client.subscribeToTopicAsync(new SubscribeToTopicRequest().setTopic("abc"), (x) -> {
+        subRespAsync = client.subscribeToTopicAsync(new SubscribeToTopicRequest().withTopic("abc"), (x) -> {
             if (!Thread.currentThread().getName().contains("pool")) {
                 finalReceivedMessage3.completeExceptionally(
                         new RuntimeException("Ran on event loop instead of executor"));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In release 1.6.0, I updated the Greengrass data model setters so that they return `this` so that calls could be chained. Unfortunately this broke binary compatibility which is necessary for Greengrass to maintain backward compatibility. This change should be released as version 1.7.0; it is compatible with versions <1.6.0. Users who are using >=1.6.0, will be able to upgrade to this version if they are not using the return value from the setters. They can also simply swap the calls to setX with a call to withX.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
