### PR TITLE
MQTT Username concatenate metrics query parameters

### DIFF
--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
@@ -522,7 +522,11 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
             if (connectionConfig.getUsername() != null) {
                 usernameOrEmpty = connectionConfig.getUsername();
             }
-            connectionConfig.setUsername(String.format("%s?SDK=JavaV2&Version=%s", usernameOrEmpty, new PackageInfo().version.toString()));
+            String queryStringConcatenation = "?";
+            if (usernameOrEmpty.contains("?")) {
+                queryStringConcatenation = "&";
+            }
+            connectionConfig.setUsername(String.format("%s%sSDK=JavaV2&Version=%s", usernameOrEmpty, queryStringConcatenation, new PackageInfo().version.toString()));
 
             if (connectionConfig.getUseWebsockets() && connectionConfig.getWebsocketHandshakeTransform() == null) {
                 if (websocketCredentialsProvider == null) {


### PR DESCRIPTION
*Issue #, if available:* #154 (https://github.com/aws/aws-iot-device-sdk-java-v2/issues/154#issuecomment-1055873576)

*Description of changes:*

When setting the MQTT username to be a query string, the concatenated metrics make it invalid.
This makes impossible to use custom authorizers with signing or without a default authorizer.
This PR chooses the concatenation character accordingly to the existing username.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
