### PR TITLE
Add ECC support for PKCS11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ mvn clean install
 # NOTE: use the latest version of the CRT here
 
 
-git clone --branch v0.16.3 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
+git clone --branch v0.16.4 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git
 cd aws-crt-java
 mvn install -Dmaven.test.skip=true
@@ -86,7 +86,7 @@ Supports API 26 or newer.
 NOTE: The shadow sample does not currently complete on android due to its dependence on stdin keyboard input.
 
 ``` sh
-git clone --branch v0.16.3 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
+git clone --branch v0.16.4 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git
 cd aws-crt-java/android
 ./gradlew connectedCheck # optional, will run the unit tests on any connected devices/emulators
@@ -107,7 +107,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'software.amazon.awssdk.crt:android:0.16.3'
+    implementation 'software.amazon.awssdk.crt:android:0.16.4'
 }
 ```
 #### Caution

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -91,7 +91,7 @@ repositories {
 }
 
 dependencies {
-    api 'software.amazon.awssdk.crt:aws-crt-android:0.16.3'
+    api 'software.amazon.awssdk.crt:aws-crt-android:0.16.4'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.16.3</version>
+      <version>0.16.4</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Update aws-crt dependency to get support. Actual implementation comes from PR https://github.com/awslabs/aws-c-io/pull/479

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
