### PR TITLE
Update to Samples README to correctly reflect arguments needed

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -161,7 +161,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 To run the websocket connect use the following command:
 
 ```sh
-mvn compile exec:java -pl samples/WebsocketConnect -Dexec.mainClass=websocketconnect.WebsocketConnect -Dexec.args='--endpoint <endpoint> --cert <path to certificate> --key <path to private key> --ca_file <path to root CA>'
+mvn compile exec:java -pl samples/WebsocketConnect -Dexec.mainClass=websocketconnect.WebsocketConnect -Dexec.args='--endpoint <endpoint> --signing_region <signing region> --ca_file <path to root CA>'
 ```
 
 Note that using Websockets will attempt to fetch the AWS credentials from your enviornment variables or local files.


### PR DESCRIPTION
*Description of changes:*

Corrects the Websocket Connection arguments showing it needs a key and certificate, and missing the required `--signing_region` argument.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
