### PR TITLE
Remove OpenSuse from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           - manylinux2014-x64
           - al2-x64
           - fedora-34-x64
-          - opensuse-leap
           - rhel8-x64
           #- manylinux2014-x86 until we find 32-bit linux binaries we can use
     steps:


### PR DESCRIPTION
*Description of changes:*

Removes OpenSuse-leap from CI due to it repeatedly causing issues with CI.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
