### PR TITLE
add ability to read actual port bound when port auto selected by OS

### DIFF
--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/RpcServer.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/RpcServer.java
@@ -32,6 +32,7 @@ public class RpcServer implements AutoCloseable {
     private ServerTlsContext tlsContext;
     private ServerListener listener;
     private AtomicBoolean serverRunning;
+    private int boundPort = -1;
 
     public RpcServer(EventLoopGroup eventLoopGroup, SocketOptions socketOptions, TlsContextOptions tlsContextOptions, String hostname, int port, EventStreamRPCServiceHandler serviceHandler) {
         this.eventLoopGroup = eventLoopGroup;
@@ -72,7 +73,23 @@ public class RpcServer implements AutoCloseable {
                     LOGGER.info("Server connection closed code [" + CRT.awsErrorString(errorCode) + "]: " + serverConnection.getResourceLogDescription());
                 }
             });
+
+        if (port == 0 && (socketOptions.domain == SocketOptions.SocketDomain.IPv4 || socketOptions.domain == SocketOptions.SocketDomain.IPv6)) {
+            boundPort = listener.getBoundPort();
+        } else {
+            boundPort = port;
+        }
+
         LOGGER.info("IpcServer started...");
+    }
+
+    /**
+     * Get port bound to.
+     *
+     * @return port number where actually service bound. Return -1 on errors
+     */
+    public int getBoundPort() {
+        return boundPort;
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-java-v2/issues/279

*Description of changes:*
Added ability to read actual port which IPC/RPC service bound to.
Related by changes proposed on aws-crt-java in [PR-489](https://github.com/awslabs/aws-crt-java/pull/489)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
