### PR TITLE
Fix aws-crt-jni.dll files filling up Windows temp dir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ mkdir sdk-workspace
 cd sdk-workspace
 # Clone the CRT repository
 #     (Use the latest version of the CRT here instead of "v0.16.4")
-git clone --branch v0.16.12 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
+git clone --branch v0.16.13 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
 cd aws-crt-java
 # Compile and install the CRT
 mvn install -Dmaven.test.skip=true
@@ -102,7 +102,7 @@ mkdir sdk-workspace
 cd sdk-workspace
 # Clone the CRT repository
 #     (Use the latest version of the CRT here instead of "v0.16.4")
-git clone --branch v0.16.12 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
+git clone --branch v0.16.13 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
 # Compile and install the CRT for Android
 cd aws-crt-java/android
 ./gradlew connectedCheck # optional, will run the unit tests on any connected devices/emulators
@@ -126,7 +126,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'software.amazon.awssdk.crt:android:0.16.12'
+    implementation 'software.amazon.awssdk.crt:android:0.16.13'
 }
 ```
 

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -91,7 +91,7 @@ repositories {
 }
 
 dependencies {
-    api 'software.amazon.awssdk.crt:aws-crt-android:0.16.12'
+    api 'software.amazon.awssdk.crt:aws-crt-android:0.16.13'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.16.12</version>
+      <version>0.16.13</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Update to latest aws-crt. Contains [fix](https://github.com/awslabs/aws-crt-java/pull/493) that, on startup, deletes any .dll files it finds from previous runs of the library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
