### PR TITLE
docs: remove developer preview note from GGV2 client

### DIFF
--- a/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/client/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCClientV2.java
+++ b/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/client/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCClientV2.java
@@ -82,9 +82,6 @@ import java.util.function.Function;
 
 /**
  * V2 Client for Greengrass.
- * !! Developer Preview !! - This class is currently in developer preview.
- * The interface is not guaranteed to be stable yet.
- * Please report any issues or make suggestions in https://github.com/aws/aws-iot-device-sdk-java-v2/issues
  */
 public class GreengrassCoreIPCClientV2 implements AutoCloseable {
   protected GreengrassCoreIPC client;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Take the Greengrass V2 client out of developer preview.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
