### PR TITLE
Mention the default ClientID in the sample readme

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -52,6 +52,8 @@ On startup, the device connects to the server, subscribes to a topic, and begins
 
 source: `samples/BasicPubSub`
 
+Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
+
 <details>
 <summary>(see sample policy)</summary>
 <pre>
@@ -91,8 +93,6 @@ source: `samples/BasicPubSub`
 </pre>
 </details>
 
-<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
-
 To Run this sample, use the following command:
 ```sh
 # Windows Platform: Windows command prompt does not support single quote, please use double quote.
@@ -105,7 +105,7 @@ This sample makes an MQTT connection using a certificate and key file. On startu
 
 Source: `samples/BasicConnect`
 
-Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect.
+Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
 
 <details>
 <summary>(see sample policy)</summary>
@@ -126,8 +126,6 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 }
 </pre>
 </details>
-
-<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To run the basic connect sample use the following command:
 
@@ -141,7 +139,7 @@ This sample makes an MQTT connection via websockets and then disconnects. On sta
 
 Source: `samples/WebsocketConnect`
 
-Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect.
+Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
 
 <details>
 <summary>(see sample policy)</summary>
@@ -162,8 +160,6 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 }
 </pre>
 </details>
-
-<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To run the websocket connect use the following command:
 
@@ -227,7 +223,7 @@ To run this sample using [SoftHSM2](https://www.opendnssec.org/softhsm/) as the 
     mvn compile exec:java -pl samples/Pkcs11Connect -Dexec.mainClass=pkcs11connect.Pkcs11Connect -Dexec.args='--endpoint <endpoint> --cert <path to certificate> --ca_file <path to root CA> --pkcs11_lib <path to PKCS11 lib> --pin <user-pin> --token_label <token-label> --key_label <key-label>'
     ```
 
-Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect.
+Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
 
 <details>
 <summary>(see sample policy)</summary>
@@ -248,8 +244,6 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 }
 </pre>
 </details>
-
-<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ## WindowsCert Connect
 
@@ -314,7 +308,7 @@ To run this sample with a basic certificate from AWS IoT Core:
     mvn compile exec:java -pl samples/WindowsCertConnect "-Dexec.mainClass=windowscertconnect.WindowsCertConnect" "-Dexec.args=--endpoint <endpoint> --cert <path to certificate> --ca_file <path to root CA>"
     ```
 
-Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect.
+Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
 
 <details>
 <summary>(see sample policy)</summary>
@@ -335,8 +329,6 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 }
 </pre>
 </details>
-
-<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ## Custom Authorizer Connect
 
@@ -344,7 +336,7 @@ This sample makes an MQTT connection and connects through a [Custom Authorizer](
 
 Source: `samples/CustomAuthorizerConnect`
 
-Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect.
+Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
 
 <details>
 <summary>(see sample policy)</summary>
@@ -365,8 +357,6 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 }
 </pre>
 </details>
-
-<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To run the custom authorizer connect use the following command:
 
@@ -404,10 +394,7 @@ To Run:
 mvn compile exec:java -pl samples/Shadow -Dexec.mainClass=shadow.ShadowSample -Dexec.args='--endpoint <endpoint> --ca_file <path to root CA> --cert <path to certificate> --key <path to private key> --thing_name <thing name>'
 ```
 
-Your Thing's
-[Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html)
-must provide privileges for this sample to connect, subscribe, publish,
-and receive.
+Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect, subscribe, publish, and receive. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
 
 <details>
 <summary>Sample Policy</summary>
@@ -461,8 +448,6 @@ and receive.
 </pre>
 </details>
 
-<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
-
 ## Jobs
 
 This sample uses the AWS IoT
@@ -482,10 +467,7 @@ To Run:
 mvn compile exec:java -pl samples/Jobs -Dexec.mainClass=jobs.JobsSample -Dexec.args='--endpoint <endpoint> --ca_file <path to root CA> --cert <path to certificate> --key <path to private key> --thing_name <thing name>'
 ```
 
-Your Thing's
-[Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html)
-must provide privileges for this sample to connect, subscribe, publish,
-and receive.
+Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect, subscribe, publish, and receive. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
 
 <details>
 <summary>Sample Policy</summary>
@@ -539,8 +521,6 @@ and receive.
 </pre>
 </details>
 
-<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
-
 ## Fleet provisioning
 
 This sample uses the AWS IoT
@@ -568,10 +548,7 @@ mvn compile exec:java -pl samples/Identity -Dexec.mainClass="identity.FleetProvi
 --cert <path to certificate> --key <path to private key> --template_name <template name> --template_parameters <template params> --csr <path to csr file>"
 ```
 
-Your Thing's
-[Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html)
-must provide privileges for this sample to connect, subscribe, publish,
-and receive.
+Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect, subscribe, publish, and receive. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
 
 <details>
 <summary>(see sample policy)</summary>
@@ -614,8 +591,6 @@ and receive.
 }
 </pre>
 </details>
-
-<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ### Fleet Provisioning Detailed Instructions
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -91,6 +91,8 @@ source: `samples/BasicPubSub`
 </pre>
 </details>
 
+*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+
 To Run this sample, use the following command:
 ```sh
 # Windows Platform: Windows command prompt does not support single quote, please use double quote.
@@ -125,6 +127,8 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
+*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+
 To run the basic connect sample use the following command:
 
 ```sh
@@ -158,6 +162,8 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 }
 </pre>
 </details>
+
+*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
 
 To run the websocket connect use the following command:
 
@@ -242,6 +248,8 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 }
 </pre>
 </details>
+
+*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
 
 ## WindowsCert Connect
 
@@ -328,6 +336,8 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
+*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+
 ## Custom Authorizer Connect
 
 This sample makes an MQTT connection and connects through a [Custom Authorizer](https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html). On startup, the device connects to the server and then disconnects. This sample is for reference on connecting using a custom authorizer.
@@ -355,6 +365,8 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 }
 </pre>
 </details>
+
+*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
 
 To run the custom authorizer connect use the following command:
 
@@ -449,6 +461,8 @@ and receive.
 </pre>
 </details>
 
+*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+
 ## Jobs
 
 This sample uses the AWS IoT
@@ -525,6 +539,8 @@ and receive.
 </pre>
 </details>
 
+*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+
 ## Fleet provisioning
 
 This sample uses the AWS IoT
@@ -598,6 +614,8 @@ and receive.
 }
 </pre>
 </details>
+
+*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
 
 ### Fleet Provisioning Detailed Instructions
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -91,7 +91,7 @@ source: `samples/BasicPubSub`
 </pre>
 </details>
 
-<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
+<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To Run this sample, use the following command:
 ```sh
@@ -127,7 +127,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
-<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
+<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To run the basic connect sample use the following command:
 
@@ -163,7 +163,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
-<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
+<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To run the websocket connect use the following command:
 
@@ -249,7 +249,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
-<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
+<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ## WindowsCert Connect
 
@@ -336,7 +336,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
-<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
+<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ## Custom Authorizer Connect
 
@@ -366,7 +366,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
-<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
+<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To run the custom authorizer connect use the following command:
 
@@ -461,7 +461,7 @@ and receive.
 </pre>
 </details>
 
-<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
+<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ## Jobs
 
@@ -539,7 +539,7 @@ and receive.
 </pre>
 </details>
 
-<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
+<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ## Fleet provisioning
 
@@ -615,7 +615,7 @@ and receive.
 </pre>
 </details>
 
-<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
+<sub>*Make sure your policy allows a client ID of `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ### Fleet Provisioning Detailed Instructions
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -91,7 +91,7 @@ source: `samples/BasicPubSub`
 </pre>
 </details>
 
-*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To Run this sample, use the following command:
 ```sh
@@ -127,7 +127,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
-*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To run the basic connect sample use the following command:
 
@@ -163,7 +163,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
-*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To run the websocket connect use the following command:
 
@@ -249,7 +249,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
-*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ## WindowsCert Connect
 
@@ -336,7 +336,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
-*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ## Custom Authorizer Connect
 
@@ -366,7 +366,7 @@ Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-
 </pre>
 </details>
 
-*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 To run the custom authorizer connect use the following command:
 
@@ -461,7 +461,7 @@ and receive.
 </pre>
 </details>
 
-*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ## Jobs
 
@@ -539,7 +539,7 @@ and receive.
 </pre>
 </details>
 
-*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ## Fleet provisioning
 
@@ -615,7 +615,7 @@ and receive.
 </pre>
 </details>
 
-*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*
+<sub>*Note: This sample uses a `client_id` set to `test-<numbers>` by default. Make sure your policy allows `test-*` to connect or use `--cliend_id <client ID here>` to send the client ID your policy supports.*</sub>
 
 ### Fleet Provisioning Detailed Instructions
 


### PR DESCRIPTION
*Description of changes:*

Adds a note to mention the default client ID used for the samples, reducing confusion on what client ID is needed. This is especially helpful if you are transitioning from the V1 SDK and are trying to use a V1 SDK sample policy, as the V1 SDK samples use a different default client ID.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
