### PR TITLE
Fix for CRT resource hang in samples

### DIFF
--- a/samples/BasicConnect/src/main/java/basicconnect/BasicConnect.java
+++ b/samples/BasicConnect/src/main/java/basicconnect/BasicConnect.java
@@ -84,6 +84,9 @@ public class BasicConnect {
             // (see sampleConnectAndDisconnect for implementation)
             cmdUtils.sampleConnectAndDisconnect(connection);
 
+            // Close the connection now that we are completely done with it.
+            connection.close();
+
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
             onApplicationFailure(ex);
         }

--- a/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
+++ b/samples/BasicPubSub/src/main/java/pubsub/PubSub.java
@@ -127,6 +127,10 @@ public class PubSub {
 
             CompletableFuture<Void> disconnected = connection.disconnect();
             disconnected.get();
+
+            // Close the connection now that we are completely done with it.
+            connection.close();
+
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
             onApplicationFailure(ex);
         }

--- a/samples/CustomAuthorizerConnect/src/main/java/customauthorizerconnect/CustomAuthorizerConnect.java
+++ b/samples/CustomAuthorizerConnect/src/main/java/customauthorizerconnect/CustomAuthorizerConnect.java
@@ -78,6 +78,9 @@ public class CustomAuthorizerConnect {
             // (see sampleConnectAndDisconnect for implementation)
             cmdUtils.sampleConnectAndDisconnect(connection);
 
+            // Close the connection now that we are completely done with it.
+            connection.close();
+
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
             onApplicationFailure(ex);
         }

--- a/samples/Identity/src/main/java/identity/FleetProvisioningSample.java
+++ b/samples/Identity/src/main/java/identity/FleetProvisioningSample.java
@@ -170,6 +170,10 @@ public class FleetProvisioningSample {
 
             CompletableFuture<Void> disconnected = connection.disconnect();
             disconnected.get();
+
+            // Close the connection now that we are completely done with it.
+            connection.close();
+
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
             System.out.println("Exception encountered: " + ex.toString());
         }

--- a/samples/Jobs/src/main/java/jobs/JobsSample.java
+++ b/samples/Jobs/src/main/java/jobs/JobsSample.java
@@ -278,6 +278,10 @@ public class JobsSample {
 
             CompletableFuture<Void> disconnected = connection.disconnect();
             disconnected.get();
+
+            // Close the connection now that we are completely done with it.
+            connection.close();
+
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
             System.out.println("Exception encountered: " + ex.toString());
         }

--- a/samples/Pkcs11Connect/src/main/java/pkcs11connect/Pkcs11Connect.java
+++ b/samples/Pkcs11Connect/src/main/java/pkcs11connect/Pkcs11Connect.java
@@ -142,6 +142,9 @@ public class Pkcs11Connect {
                     CompletableFuture<Void> disconnected = connection.disconnect();
                     disconnected.get();
                     System.out.println("Disconnected.");
+
+                    // Close the connection now that we are completely done with it.
+                    connection.close();
                 }
             } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
                 onApplicationFailure(ex);

--- a/samples/RawConnect/src/main/java/rawconnect/RawConnect.java
+++ b/samples/RawConnect/src/main/java/rawconnect/RawConnect.java
@@ -128,6 +128,9 @@ public class RawConnect {
                     // Connect and disconnect using the connection we created
                     // (see sampleConnectAndDisconnect for implementation)
                     cmdUtils.sampleConnectAndDisconnect(connection);
+
+                    // Close the connection now that we are completely done with it.
+                    connection.close();
                 }
             }
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {

--- a/samples/Shadow/src/main/java/shadow/ShadowSample.java
+++ b/samples/Shadow/src/main/java/shadow/ShadowSample.java
@@ -291,6 +291,10 @@ public class ShadowSample {
 
             CompletableFuture<Void> disconnected = connection.disconnect();
             disconnected.get();
+
+            // Close the connection now that we are completely done with it.
+            connection.close();
+
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
             System.out.println("Exception encountered: " + ex.toString());
         }

--- a/samples/Utils/CommandLineUtils/utils/commandlineutils/CommandLineUtils.java
+++ b/samples/Utils/CommandLineUtils/utils/commandlineutils/CommandLineUtils.java
@@ -185,7 +185,10 @@ public class CommandLineUtils {
             buildConnectionSetupCAFileDefaults(builder);
             buildConnectionSetupConnectionDefaults(builder, callbacks);
 
-            return builder.build();
+            MqttClientConnection conn = builder.build();
+            builder.close();
+            return conn;
+
         } catch (CrtRuntimeException ex) {
             return null;
         }
@@ -226,7 +229,9 @@ public class CommandLineUtils {
             X509CredentialsProvider provider = x509builder.build();
             builder.withWebsocketCredentialsProvider(provider);
 
-            return builder.build();
+            MqttClientConnection conn = builder.build();
+            builder.close();
+            return conn;
 
         } catch (CrtRuntimeException ex) {
             return null;
@@ -245,7 +250,9 @@ public class CommandLineUtils {
             builder.withWebsockets(true);
             builder.withWebsocketSigningRegion(getCommandRequired(m_cmd_signing_region, ""));
 
-            return builder.build();
+            MqttClientConnection conn = builder.build();
+            builder.close();
+            return conn;
 
         } catch (CrtRuntimeException ex) {
             return null;
@@ -261,7 +268,10 @@ public class CommandLineUtils {
             buildConnectionSetupCAFileDefaults(builder);
             buildConnectionSetupConnectionDefaults(builder, callbacks);
             buildConnectionSetupProxyDefaults(builder);
-            return builder.build();
+
+            MqttClientConnection conn = builder.build();
+            builder.close();
+            return conn;
         }
         catch (CrtRuntimeException ex) {
             return null;
@@ -279,7 +289,10 @@ public class CommandLineUtils {
                 getCommandOrDefault(m_cmd_custom_auth_authorizer_name, null),
                 getCommandOrDefault(m_cmd_custom_auth_authorizer_signature, null),
                 getCommandOrDefault(m_cmd_custom_auth_password, null));
-            return builder.build();
+
+            MqttClientConnection conn = builder.build();
+            builder.close();
+            return conn;
         }
         catch (CrtRuntimeException | UnsupportedEncodingException ex) {
             return null;

--- a/samples/WebsocketConnect/src/main/java/websocketconnect/WebsocketConnect.java
+++ b/samples/WebsocketConnect/src/main/java/websocketconnect/WebsocketConnect.java
@@ -77,6 +77,9 @@ public class WebsocketConnect {
             // (see sampleConnectAndDisconnect for implementation)
             cmdUtils.sampleConnectAndDisconnect(connection);
 
+            // Close the connection now that we are completely done with it.
+            connection.close();
+
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
             onApplicationFailure(ex);
         }

--- a/samples/WindowsCertConnect/src/main/java/windowscertconnect/WindowsCertConnect.java
+++ b/samples/WindowsCertConnect/src/main/java/windowscertconnect/WindowsCertConnect.java
@@ -91,6 +91,9 @@ public class WindowsCertConnect {
                 // Connect and disconnect using the connection we created
                 // (see sampleConnectAndDisconnect for implementation)
                 cmdUtils.sampleConnectAndDisconnect(connection);
+
+                // Close the connection now that we are completely done with it.
+                connection.close();
             }
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
             onApplicationFailure(ex);

--- a/samples/X509CredentialsProviderConnect/src/main/java/x509credentialsproviderconnect/X509CredentialsProviderConnect.java
+++ b/samples/X509CredentialsProviderConnect/src/main/java/x509credentialsproviderconnect/X509CredentialsProviderConnect.java
@@ -77,6 +77,9 @@ public class X509CredentialsProviderConnect {
             // (see sampleConnectAndDisconnect for implementation)
             cmdUtils.sampleConnectAndDisconnect(connection);
 
+            // Close the connection now that we are completely done with it.
+            connection.close();
+
         } catch (CrtRuntimeException | InterruptedException | ExecutionException ex) {
             onApplicationFailure(ex);
         }


### PR DESCRIPTION
*Description of changes:*

Fixes the hang due to CRT resources not being cleaned up correctly in samples. This was due to two things: The first being the builders were not being correctly cleaned in the command line utils, and the second being the connection was not closed after disconnecting. Both of these were leading to CRT resources hanging around, causing the 1 minute hang.

This PR fixes both issues and now the samples complete instantly once they are finished, as expected.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
