### PR TITLE
Added code to print out byte array data

### DIFF
--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/DeserializationException.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/DeserializationException.java
@@ -1,11 +1,21 @@
 package software.amazon.awssdk.eventstreamrpc;
 
+import java.util.Arrays;
+
 public class DeserializationException extends RuntimeException {
     public DeserializationException(Object lexicalData) {
         this(lexicalData, null);
     }
 
     public DeserializationException(Object lexicalData, Throwable cause) {
-        super("Could not deserialize data: [" + lexicalData.toString() + "]", cause);
+        super("Could not deserialize data: [" + stringify(lexicalData) + "]", cause);
+    }
+
+    private static String stringify(Object lexicalData) {
+        if (lexicalData instanceof byte[]) {
+            return Arrays.toString((byte[]) lexicalData);
+        }
+
+        return lexicalData.toString();
     }
 }


### PR DESCRIPTION
I was working with Greengrass V2 IPC and sent an invalid IPC message to the Nucleus. When it received the message it printed out the following message:

```
2022-08-03T16:13:13.896Z [ERROR] (Thread-7) software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler: [aws.greengrass#PublishToIoTCore] operation threw unexpected software.amazon.awssdk.eventstreamrpc.DeserializationException: Could not deserialize data: [[B@41467268]. {}
```

The deserialized data is hidden by the `[B@41467268` string. This commit adds a stringify() method to the DeserializationException class to convert the data into a string that can be used for debugging and shows the exact array contents byte by byte.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
