### PR TITLE
update CRT to latest

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.18.2</version>
+      <version>0.19.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Pick up aws-c-common fix for dlopen usage from mac

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
