### PR TITLE
ensure aws-crt version is consistent everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,17 @@ jobs:
     runs-on: ubuntu-20.04 # latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Check docs
         run: |
           mvn install -Dmaven.test.skip
           ./make-docs.py
+
+  # ensure that aws-crt version is consistent among different files
+  consistent-crt-version:
+    runs-on: ubuntu-20.04 # latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Consistent aws-crt version
+        run: |
+          ./update-crt.py --check-consistency
+

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ mkdir sdk-workspace
 cd sdk-workspace
 # Clone the CRT repository
 #     (Use the latest version of the CRT here instead of "v0.18.0")
-git clone --branch v0.18.0 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
+git clone --branch v0.19.3 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
 cd aws-crt-java
 # Compile and install the CRT
 mvn install -Dmaven.test.skip=true
@@ -103,7 +103,7 @@ mkdir sdk-workspace
 cd sdk-workspace
 # Clone the CRT repository
 #     (Use the latest version of the CRT here instead of "v0.18.0")
-git clone --branch v0.18.0 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
+git clone --branch v0.19.3 --recurse-submodules https://github.com/awslabs/aws-crt-java.git
 # Compile and install the CRT for Android
 cd aws-crt-java/android
 ./gradlew connectedCheck # optional, will run the unit tests on any connected devices/emulators
@@ -127,7 +127,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'software.amazon.awssdk.crt:android:0.18.0'
+    implementation 'software.amazon.awssdk.crt:android:0.19.3'
 }
 ```
 


### PR DESCRIPTION
**ISSUE:**
Several files state which version of `aws-crt` to use. When we edit these files by hand, they tend to get out of sync. So we added a script to help, but sometimes people forgot to use the script.

**DESCRIPTION OF CHANGES:**
Add a CI check to ensure the files are in sync.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
