### PR TITLE
Fix Docs CI

### DIFF
--- a/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnection.java
+++ b/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnection.java
@@ -28,12 +28,12 @@ public class EventStreamRPCConnection implements AutoCloseable {
             CONNECTED,
             CLOSING
         };
-        
+
         Phase connectionPhase;
         ClientConnection connection;
         Throwable closeReason;
         boolean onConnectCalled;
-        
+
         protected ConnectionState(Phase phase, ClientConnection connection) {
             this.connectionPhase = phase;
             this.connection = connection;
@@ -62,7 +62,7 @@ public class EventStreamRPCConnection implements AutoCloseable {
 
     /**
      * Connects to the event stream RPC server asynchronously
-     * 
+     *
      * @return
      */
     public CompletableFuture<Void> connect(final LifecycleHandler lifecycleHandler) {
@@ -143,7 +143,7 @@ public class EventStreamRPCConnection implements AutoCloseable {
                                     LOGGER.warning("AccessDenied to event stream RPC server");
                                     connectionState.connectionPhase = ConnectionState.Phase.CLOSING;
                                     connectionState.connection.closeConnection(0);
-                                    
+
                                     final AccessDeniedException ade = new AccessDeniedException("Connection access denied to event stream RPC server");
                                     if (!initialConnectFuture.isDone()) {
                                         initialConnectFuture.completeExceptionally(ade);
@@ -166,7 +166,7 @@ public class EventStreamRPCConnection implements AutoCloseable {
                             disconnect();
                         } else if (MessageType.ProtocolError.equals(messageType) || MessageType.ServerError.equals(messageType)) {
                             LOGGER.severe("Received " + messageType.name() + ": " + CRT.awsErrorName(CRT.awsLastError()));
-                            connectionState.closeReason = EventStreamError.create(headers, payload, messageType);                            
+                            connectionState.closeReason = EventStreamError.create(headers, payload, messageType);
                             doOnError(lifecycleHandler, connectionState.closeReason);
                             disconnect();
                         } else {
@@ -344,7 +344,7 @@ public class EventStreamRPCConnection implements AutoCloseable {
          * result in closing the connection. AccessDeniedException is such an example
          *
          * @param t Exception
-         * @returns true if the connection should be terminated as a result of handling the error
+         * @return true if the connection should be terminated as a result of handling the error
          */
         boolean onError(Throwable t);
 

--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
@@ -157,8 +157,8 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
             return new AwsIotMqttConnectionBuilder(tlsContextOptions);
         }
     }
-    
-    /**     
+
+    /**
      * Create a new builder with mTLS, using a certificate in a Windows certificate store.
      *
      * NOTE: Windows only
@@ -550,7 +550,7 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
      * @param authorizerSignature The signature of the custom authorizer. If null is passed, then 'x-amz-customauthorizer-signature'
      *                  will not be added with the MQTT connection.
      * @param password The password to use with the custom authorizer. If null is passed, then no password will be set.
-     * @return
+     * @return {@link AwsIotMqttConnectionBuilder}
      */
     public AwsIotMqttConnectionBuilder withCustomAuthorizer(String username, String authorizerName, String authorizerSignature, String password) {
         isUsingCustomAuthorizer = true;


### PR DESCRIPTION
*Description of changes:*

Fixes the documentation CI failing. Fixes this by changing a `@returns` to `@return` which was causing the issue.

There is still a **LOT** of errors that need to be tackled due to missing documentation in Greengrass, the Shadows client, and likely other generated models (Jobs, etc).

However, this PR will fix CI and make all the other issues warnings rather than errors until we have a chance to fully document everything.

Edit: Also fixes a missing return in the MQTT builder for custom authentication I noticed while working through the documentation.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
