### PR TITLE
Document all event-stream-rpc classes

### DIFF
--- a/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCClient.java
+++ b/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCClient.java
@@ -23,6 +23,10 @@ public class EventStreamRPCClient {
     private static final Logger LOGGER = Logger.getLogger(EventStreamRPCClient.class.getName());
     private final EventStreamRPCConnection connection;
 
+    /**
+      * Creates a new EventStreamRPCClient
+      * @param connection The connection for the EventStreamRPCClient to use
+      */
     public EventStreamRPCClient(EventStreamRPCConnection connection) {
         if (connection == null) {
             throw new IllegalArgumentException("Cannot create eventstream RPC client with null connection");
@@ -32,8 +36,14 @@ public class EventStreamRPCClient {
 
     /**
      * Work horse of all operations, streaming or otherwise.
-     *
-     * @return
+     * @param <ReqType> The request type
+     * @param <RespType> The response type
+     * @param <StrReqType> The streaming request type
+     * @param <StrRespType> The streaming response type
+     * @param operationModelContext The operation context
+     * @param request The request
+     * @param streamResponseHandler The streaming handler
+     * @return The operation result
      */
     public <ReqType extends EventStreamJsonMessage,
             RespType extends EventStreamJsonMessage,
@@ -135,7 +145,7 @@ public class EventStreamRPCClient {
                     }
                 }
             }
-            
+
             @Override
             protected void onContinuationClosed() {
                 super.onContinuationClosed();
@@ -159,10 +169,10 @@ public class EventStreamRPCClient {
         return response;
     }
 
-    
+
 
     /**
-     * Sends an empty close message on the open stream. 
+     * Sends an empty close message on the open stream.
      * @param continuation continuation to send the close message on
      * @return CompletableFuture indicating flush of the close message.
      */

--- a/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnectionConfig.java
+++ b/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnectionConfig.java
@@ -31,6 +31,16 @@ public class EventStreamRPCConnectionConfig {
      */
     private final Supplier<CompletableFuture<MessageAmendInfo>> connectMessageAmender;
 
+    /**
+     * Creates a new EventStreamRPCConnectionConfig with the given data
+     * @param clientBootstrap The ClientBootstrap to use
+     * @param eventLoopGroup The EventLoopGroup to use
+     * @param socketOptions The SocketOptions to use
+     * @param tlsContext The TlsContext to use
+     * @param host The host name to use
+     * @param port The host port to use
+     * @param connectMessageAmender The connect message amender to use
+     */
     public EventStreamRPCConnectionConfig(ClientBootstrap clientBootstrap, EventLoopGroup eventLoopGroup,
                                           SocketOptions socketOptions, ClientTlsContext tlsContext,
                                           String host, int port, Supplier<CompletableFuture<MessageAmendInfo>> connectMessageAmender) {
@@ -52,30 +62,58 @@ public class EventStreamRPCConnectionConfig {
         }
     }
 
+    /**
+     * Returns the ClientBootstrap associated with the EventStreamRPCConnectionConfig
+     * @return the ClientBootstrap associated with the EventStreamRPCConnectionConfig
+     */
     public ClientBootstrap getClientBootstrap() {
         return clientBootstrap;
     }
 
+    /**
+     * Returns the EventLoopGroup associated with the EventStreamRPCConnectionConfig
+     * @return the EventLoopGroup associated with the EventStreamRPCConnectionConfig
+     */
     public EventLoopGroup getEventLoopGroup() {
         return eventLoopGroup;
     }
 
+    /**
+     * Returns the SocketOptions associated with the EventStreamRPCConnectionConfig
+     * @return The SocketOptions associated with the EventStreamRPCConnectionConfig
+     */
     public SocketOptions getSocketOptions() {
         return socketOptions;
     }
 
+    /**
+     * Returns the TlsContext associated with the EventStreamRPCConnectionConfig
+     * @return The TlsContext associated with the EventStreamRPCConnectionConfig
+     */
     public ClientTlsContext getTlsContext() {
         return tlsContext;
     }
 
+    /**
+     * Returns the host name associated with the EventStreamRPCConnectionConfig
+     * @return The host name associated with the EventStreamRPCConnectionConfig
+     */
     public String getHost() {
         return host;
     }
 
+    /**
+     * Returns the port associated with the EventStreamRPCConnectionConfig
+     * @return The port associated with the EventStreamRPCConnectionConfig
+     */
     public int getPort() {
         return port;
     }
 
+    /**
+     * Returns the connect message amender associated with the EventStreamRPCConnectionConfig
+     * @return The connect message amender associated with the EventStreamRPCConnectionConfig
+     */
     public Supplier<CompletableFuture<MessageAmendInfo>> getConnectMessageAmender() {
         return connectMessageAmender;
     }

--- a/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/GreengrassConnectMessageSupplier.java
+++ b/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/GreengrassConnectMessageSupplier.java
@@ -9,8 +9,16 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+/**
+ * The connect message supplier for Greengrass
+ */
 public class GreengrassConnectMessageSupplier {
-    
+
+    /**
+     * Returns a new connect message supplier using the given token
+     * @param authToken The auth token to use
+     * @return A new connect message supplier
+     */
     public static Supplier<CompletableFuture<MessageAmendInfo>> connectMessageSupplier(String authToken) {
         return () -> {
             final List<Header> headers = new LinkedList<>();

--- a/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/GreengrassEventStreamConnectMessage.java
+++ b/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/GreengrassEventStreamConnectMessage.java
@@ -1,13 +1,24 @@
 package software.amazon.awssdk.eventstreamrpc;
 
+/**
+ * A Greengrass EventStream connection message
+ */
 public class GreengrassEventStreamConnectMessage {
 
     private String authToken;
 
+    /**
+     * Sets the authorization token in the connect message
+     * @param authToken the authorization token to use
+     */
     public void setAuthToken(String authToken) {
         this.authToken = authToken;
     }
 
+    /**
+     * Returns the authorization token in the connect message
+     * @return authorization token in the connect message
+     */
     public String getAuthToken() {
         return this.authToken;
     }

--- a/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationResponse.java
+++ b/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationResponse.java
@@ -17,8 +17,8 @@ import java.util.logging.Logger;
  * client, closing of any open stream, and retrieval of response. Specific generated operation response
  * handlers are usually simple wrappers with the generic types specified
  *
- * @param <ResponseType>
- * @param <StreamRequestType>
+ * @param <ResponseType> The response type
+ * @param <StreamRequestType> The stream response type
  */
 public class OperationResponse<ResponseType extends EventStreamJsonMessage,
                         StreamRequestType extends EventStreamJsonMessage>
@@ -30,6 +30,13 @@ public class OperationResponse<ResponseType extends EventStreamJsonMessage,
     private final CompletableFuture<Void> requestFlushFuture;
     private final AtomicBoolean isClosed;
 
+    /**
+     * Creates a new OperationResponse from the given data
+     * @param operationModelContext The operation model context to use
+     * @param continuation The continuation to use
+     * @param responseFuture The response future to use
+     * @param requestFlushFuture The request flush future to use
+     */
     public OperationResponse(OperationModelContext<ResponseType, ?, StreamRequestType, ?> operationModelContext,
                              ClientConnectionContinuation continuation,
                              CompletableFuture<ResponseType> responseFuture,
@@ -41,6 +48,10 @@ public class OperationResponse<ResponseType extends EventStreamJsonMessage,
         this.isClosed = new AtomicBoolean(continuation != null && !continuation.isNull());
     }
 
+    /**
+     * Returns the request flush future to use
+     * @return The request flush future to use
+     */
     final public CompletableFuture<Void> getRequestFlushFuture() {
         return requestFlushFuture;
     }
@@ -52,7 +63,8 @@ public class OperationResponse<ResponseType extends EventStreamJsonMessage,
      * May throw exception if requestFlushFuture throws an exception and will
      * block if requestFlush has not completed.
      *
-     * @return
+     * @return the response completable future to wait on the initial response
+     * if there is one.
      */
     public CompletableFuture<ResponseType> getResponse() {
         //semantics here are: if the request was never successfully sent
@@ -98,7 +110,7 @@ public class OperationResponse<ResponseType extends EventStreamJsonMessage,
     /**
      * Initiate a close on the event stream from the client side.
      *
-     * @return
+     * @return A future that completes when the event stream is closed
      */
     @Override
     public CompletableFuture<Void> closeStream() {
@@ -120,7 +132,7 @@ public class OperationResponse<ResponseType extends EventStreamJsonMessage,
 
     /**
      * Checks if the stream is closed
-     * @return
+     * @return True if the stream is closed
      */
     public boolean isClosed() {
         return isClosed.get();

--- a/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamResponse.java
+++ b/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamResponse.java
@@ -4,25 +4,28 @@ import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Interface for stream responses
+ */
 public interface StreamResponse<ResponseType extends EventStreamJsonMessage, StreamRequestType extends EventStreamJsonMessage>
                         extends StreamEventPublisher<StreamRequestType> {
     /**
      * Completable future indicating flush of the request that initiated the stream operation
      *
-     * @return
+     * @return Completable future indicating flush of the request that initiated the stream operation
      */
     CompletableFuture<Void> getRequestFlushFuture();
 
     /**
      * Completable future for retrieving the initial-response of the stream operation
      *
-     * @return
+     * @return Completable future for retrieving the initial-response of the stream operation
      */
     CompletableFuture<ResponseType> getResponse();
 
     /**
      * Tests if the stream is closed
-     * @return
+     * @return True if the stream is closed
      */
     boolean isClosed();
 }

--- a/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamResponseHandler.java
+++ b/sdk/greengrass/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamResponseHandler.java
@@ -4,13 +4,13 @@ package software.amazon.awssdk.eventstreamrpc;
  * Operation response handler is needed to invoke an operation that has a streaming
  * response element to it.
  *
- * @param <StreamEventType>
+ * @param <StreamEventType> The stream event type
  */
 public interface StreamResponseHandler<StreamEventType> {
 
     /**
-     *
-     * @param streamEvent
+     * Called when there is a stream event to process
+     * @param streamEvent The stream event to process
      */
     void onStreamEvent(final StreamEventType streamEvent);
 
@@ -22,7 +22,7 @@ public interface StreamResponseHandler<StreamEventType> {
      * There are conditions when onStreamError() may be triggered but the client handling will
      * close the connection anyways.
      *
-     * @param error
+     * @param error The error that occurred
      * @return true if the stream should be closed on this error, false if stream should remain open
      */
     boolean onStreamError(final Throwable error);

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/DeserializationException.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/DeserializationException.java
@@ -1,21 +1,23 @@
 package software.amazon.awssdk.eventstreamrpc;
 
-import java.util.Arrays;
-
+/**
+ * Thrown when a deserialization exception occurs
+ */
 public class DeserializationException extends RuntimeException {
+    /**
+     * Creates a new DeserializationException from the given data
+     * @param lexicalData The data that could not be deserialized
+     */
     public DeserializationException(Object lexicalData) {
         this(lexicalData, null);
     }
 
+    /**
+     * Creates a new DeserializationException from the given data
+     * @param lexicalData The data that could not be deserialized
+     * @param cause The reason the data could not be deserialized
+     */
     public DeserializationException(Object lexicalData, Throwable cause) {
-        super("Could not deserialize data: [" + stringify(lexicalData) + "]", cause);
-    }
-
-    private static String stringify(Object lexicalData) {
-        if (lexicalData instanceof byte[]) {
-            return Arrays.toString((byte[]) lexicalData);
-        }
-
-        return lexicalData.toString();
+        super("Could not deserialize data: [" + lexicalData.toString() + "]", cause);
     }
 }

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamClosedException.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamClosedException.java
@@ -1,11 +1,22 @@
 package software.amazon.awssdk.eventstreamrpc;
 
+/**
+ * Thrown when a EventStream closed exception occurs
+ */
 public class EventStreamClosedException extends RuntimeException {
+    /**
+     * Creates a new EventStreamClosedException from the given continuation ID
+     * @param continauationId The continuation ID that caused the exception
+     */
     public EventStreamClosedException(long continauationId) {
         //TODO: Is hex formatting here useful? It is short, but not consistent anywhere else yet
         super(String.format("EventStream continuation [%s] is already closed!", Long.toHexString(continauationId)));
     }
 
+    /**
+     * Creates a new EventStreamClosedException with a given messasge
+     * @param msg The message to associated with the EventStreamClosedException
+     */
     public EventStreamClosedException(String msg) {
         //TODO: Is hex formatting here useful? It is short, but not consistent anywhere else yet
         super(msg);

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceModel.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceModel.java
@@ -345,12 +345,12 @@ public abstract class EventStreamRPCServiceModel {
     }
 
     /**
-     * Creates a EventStreamJsonMessage of type <T> from the given application model
+     * Creates a EventStreamJsonMessage of type T from the given application model
      * class and payload.
      * @param <T> The type to convert the result to
      * @param clazz The class
      * @param payload The payload
-     * @return A EventStreamMessage of type <T>
+     * @return A EventStreamMessage of type T
      */
     public <T extends EventStreamJsonMessage> T fromJson(final Class<T> clazz, byte[] payload) {
         try {

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceModel.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceModel.java
@@ -39,11 +39,29 @@ import java.util.Optional;
 public abstract class EventStreamRPCServiceModel {
     private static final Gson GSON;
 
-    //package visibility so client
+    /**
+     * Version header string
+     */
     static final String VERSION_HEADER = ":version";
+
+    /**
+     * Content type header string
+     */
     public static final String CONTENT_TYPE_HEADER = ":content-type";
+
+    /**
+     * Content type application text string
+     */
     public static final String CONTENT_TYPE_APPLICATION_TEXT = "text/plain";
+
+    /**
+     * Content type application json string
+     */
     public static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
+
+    /**
+     * Service model type header
+     */
     public static final String SERVICE_MODEL_TYPE_HEADER = "service-model-type";
 
     static {
@@ -168,9 +186,9 @@ public abstract class EventStreamRPCServiceModel {
      *
      * Note: Generated code for equals method of Smithy shapes relies on this
      *
-     * @param lhs
-     * @param rhs
-     * @return
+     * @param lhs The first to compare
+     * @param rhs The second to compare
+     * @return True if both are equal, false otherwise
      */
     public static boolean blobTypeEquals(Optional<byte[]> lhs, Optional<byte[]> rhs) {
         if (lhs.equals(rhs)) {
@@ -216,8 +234,8 @@ public abstract class EventStreamRPCServiceModel {
     }
 
     /**
-     * For actual
-     * @return
+     * For getting the actual service name
+     * @return The name of the service as a string
      */
     public abstract String getServiceName();
 
@@ -230,6 +248,11 @@ public abstract class EventStreamRPCServiceModel {
         FRAMEWORK_APPLICATION_MODEL_TYPES.put(ValidationException.ERROR_CODE, ValidationException.class);
     }
 
+    /**
+     * Returns the application model class
+     * @param applicationModelType The application model
+     * @return The class of the given application model
+     */
     final public Optional<Class<? extends EventStreamJsonMessage>> getApplicationModelClass(final String applicationModelType) {
         final Class<? extends EventStreamJsonMessage> clazz = FRAMEWORK_APPLICATION_MODEL_TYPES.get(applicationModelType);
         if (clazz != null) {
@@ -240,7 +263,7 @@ public abstract class EventStreamRPCServiceModel {
 
     /**
      * Retreives all operations on the service
-     * @return
+     * @return All operations on the service
      */
     public abstract Collection<String> getAllOperations();
 
@@ -248,8 +271,8 @@ public abstract class EventStreamRPCServiceModel {
      * Need to override per specific service type so it can look up all associated types and errors
      * possible.
      *
-     * @param applicationModelType
-     * @return
+     * @param applicationModelType The application model
+     * @return The service class type of the given application model
      */
     protected abstract Optional<Class<? extends EventStreamJsonMessage>> getServiceClassType(String applicationModelType);
 
@@ -258,8 +281,9 @@ public abstract class EventStreamRPCServiceModel {
      *
      * This may not be a useful interface as generated code will typically pull a known operation model context
      * Public visibility is useful for testing
-     * @param operationName
-     * @return
+     *
+     * @param operationName The name of the operation
+     * @return The operation context associated with the given operation name
      */
     public abstract OperationModelContext getOperationModelContext(String operationName);
 
@@ -278,13 +302,18 @@ public abstract class EventStreamRPCServiceModel {
         }
     }
 
+    /**
+     * Converts the given EventStreamJsonMessage to a JSON string
+     * @param message The message to convert
+     * @return A JSON string
+     */
     public String toJsonString(final EventStreamJsonMessage message) {
         return new String(toJson(message), StandardCharsets.UTF_8);
     }
 
     /**
      * Internal getter method can be used by subclasses of specific service models to override default Gson
-     * @return
+     * @return Returns GSON context
      */
     protected Gson getGson() {
         return GSON;
@@ -301,10 +330,11 @@ public abstract class EventStreamRPCServiceModel {
     }
 
     /**
-     * Uses this service's specific model class
-     * @param applicationModelType
-     * @param payload
-     * @return
+     * Creates a EventStreamJsonMessage from the given application model type string and payload.
+     * Uses this service's specific model class to create the EventStreamJsonMessage.
+     * @param applicationModelType The application model type string
+     * @param payload The payload
+     * @return A EventStreamMessage
      */
     public EventStreamJsonMessage fromJson(final String applicationModelType, byte[] payload) {
         final Optional<Class<? extends EventStreamJsonMessage>> clazz = getApplicationModelClass(applicationModelType);
@@ -314,6 +344,14 @@ public abstract class EventStreamRPCServiceModel {
         return fromJson(clazz.get(), payload);
     }
 
+    /**
+     * Creates a EventStreamJsonMessage of type <T> from the given application model
+     * class and payload.
+     * @param <T> The type to convert the result to
+     * @param clazz The class
+     * @param payload The payload
+     * @return A EventStreamMessage of type <T>
+     */
     public <T extends EventStreamJsonMessage> T fromJson(final Class<T> clazz, byte[] payload) {
         try {
             return getGson().fromJson(new String(payload, StandardCharsets.UTF_8), clazz);

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidDataException.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidDataException.java
@@ -3,9 +3,14 @@ package software.amazon.awssdk.eventstreamrpc;
 import software.amazon.awssdk.crt.eventstream.MessageType;
 
 /**
- * 
+ * An exception for invalid/unexpected data
  */
 public class InvalidDataException extends RuntimeException {
+    /**
+     * Constructs a new InvalidDataException with the given MessageType, whose name will
+     * be added to the exception.
+     * @param unexpectedType The MessageType that caused the exception
+     */
     public InvalidDataException(MessageType unexpectedType) {
         super(String.format("Unexpected message type received: %s", unexpectedType.name()));
     }

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/MessageAmendInfo.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/MessageAmendInfo.java
@@ -22,15 +22,33 @@ public class MessageAmendInfo {
     private final List<Header> headers;
     private final byte[] payload;
 
+    /**
+     * Constructs a new MessageAmendInfo
+     * @param headers The headers to store
+     * @param payload The payload to store
+     */
     public MessageAmendInfo(List<Header> headers, byte[] payload) {
         this.headers = headers;
         this.payload = payload;
     }
 
+    /**
+     * Returns the headers stored in the object. For sent messages,
+     * the headers stored in the object may be used to append to existing headers,
+     * where it won't overwrite an existing one that may be outgoing.
+     *
+     * @return The headers stored
+     */
     public List<Header> getHeaders() {
         return headers;
     }
 
+    /**
+     * Returns the payload stored in the object. A payload may, or may not, be used
+     * in a given MessageAmendInfo. Refer to the method that accepts or expects this
+     * structure to understand what parts are used and which are not.
+     * @return The payload stored
+     */
     public byte[] getPayload() {
         return payload;
     }

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationModelContext.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationModelContext.java
@@ -11,10 +11,10 @@ import java.util.Optional;
  * Smithy code generation should produce one of these per model, but we aren't going to take steps to prevent
  * hand construction.
  *
- * @param <RequestType>
- * @param <ResponseType>
- * @param <StreamingRequestType>
- * @param <StreamingResponseType>
+ * @param <RequestType> The initial-request
+ * @param <ResponseType> The initial-response
+ * @param <StreamingRequestType> The streaming initial-request
+ * @param <StreamingResponseType> The streaming initial-response
  */
 public interface OperationModelContext
         <RequestType extends EventStreamJsonMessage,
@@ -26,7 +26,8 @@ public interface OperationModelContext
      * Returns the service model which can look up all/any Java error class types if an
      * operation throws it so the handling has a chance
      *
-     * @return
+     * @return the service model which can look up all/any Java error class types if an
+     * operation throws it so the handling has a chance
      */
     EventStreamRPCServiceModel getServiceModel();
 
@@ -35,64 +36,65 @@ public interface OperationModelContext
      * Namespace included
      *
      * Example: aws.greengrass#SubscribeToTopic
-     * @return
+     * @return the canonical operation name associated with this context across any client language.
      */
     String getOperationName();
 
     /**
      * Returns the initial-request java class type
-     * @return
+     * @return the initial-request java class type
      */
     Class<RequestType> getRequestTypeClass();
 
     /**
      * Returns the application model type string for the initial-request object
-     * @return
+     * @return the application model type string for the initial-request object
      */
     String getRequestApplicationModelType();
 
     /**
      * Returns the initial-response java class type
-     * @return
+     * @return the initial-response java class type
      */
     Class<ResponseType> getResponseTypeClass();
 
     /**
      * Returns the application model type string for the initial response object
-     * @return
+     * @return the application model type string for the initial response object
      */
     String getResponseApplicationModelType();
 
     /**
      * Returns the streaming-request java class type
-     * @return
+     * @return the streaming-request java class type
      */
     Optional<Class<StreamingRequestType>> getStreamingRequestTypeClass();
 
     /**
      * Returns the application model type of
-     * @return
+     * @return the application model type of
      */
     Optional<String> getStreamingRequestApplicationModelType();
 
     /**
      * Returns the streaming-response java class type
      *
-     * @return
+     * @return the streaming-response java class type
      */
     Optional<Class<StreamingResponseType>> getStreamingResponseTypeClass();
 
     /**
      * Returns the streaming response application model string
      *
-     * @return
+     * @return the streaming response application model string
      */
     Optional<String> getStreamingResponseApplicationModelType();
 
     /**
      * Returns true if there is a streaming request or response associated with the operation
      * or both
-     * @return
+     * @return true if there is a streaming request or response associated with the operation
+     * or both
      */
     default boolean isStreamingOperation() {
         return getStreamingRequestTypeClass().isPresent() || getStreamingResponseTypeClass().isPresent();

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/SerializationException.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/SerializationException.java
@@ -1,10 +1,22 @@
 package software.amazon.awssdk.eventstreamrpc;
 
+/**
+ * Thrown when a serialization exception occurs
+ */
 public class SerializationException extends RuntimeException {
+    /**
+     * Creates a new serlization exception
+     * @param object The object that caused the serlization exception
+     */
     public SerializationException(Object object) {
         this(object, null);
     }
 
+    /**
+     * Creates a new serlization exception
+     * @param object The object that caused the serlization exception
+     * @param cause The cause of the serlization exception
+     */
     public SerializationException(Object object, Throwable cause) {
         super("Could not serialize object: " + object.toString(), cause);
     }

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/UnmappedDataException.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/UnmappedDataException.java
@@ -8,14 +8,28 @@ import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
  * for the operation. Or an exception (don't have to be called out).
  */
 public class UnmappedDataException extends RuntimeException {
+
+    /**
+     * Creates a new Unmapped data exception.
+     * @param applicationModelType The application model type that caused the exception
+     */
     public UnmappedDataException(String applicationModelType) {
         super(String.format("Cannot find Java class type for application model type: %s", applicationModelType));
     }
 
+    /**
+     * Creates a new Unmapped data exception.
+     * @param expectedClass The application class that caused the exception
+     */
     public UnmappedDataException(Class<? extends EventStreamJsonMessage> expectedClass) {
         super(String.format("Data does not map into Java class: %s", expectedClass.getCanonicalName()));
     }
 
+    /**
+     * Creates a new Unmapped data exception.
+     * @param applicationModelType The application model type that caused the exception
+     * @param expectedClass The application class that caused the exception
+     */
     public UnmappedDataException(String applicationModelType, Class<? extends EventStreamJsonMessage> expectedClass) {
         super(String.format("Found model-type {%s} which does not map into Java class: %s", applicationModelType, expectedClass.getCanonicalName()));
     }

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/Version.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/Version.java
@@ -9,14 +9,31 @@ import java.util.regex.Pattern;
  */
 public class Version implements Comparable<Version> {
     private final static String PATTERN_REGEX_STRING = "^(\\d+)\\.(\\d+)\\.(\\d+)$";
+    /**
+     * The Regex pattern used to parse versions from strings
+     */
     public final static Pattern PATTERN = Pattern.compile(PATTERN_REGEX_STRING);
 
+    /**
+     * Default major version number. Defaults to 0
+     */
     public static final int MAJOR = 0;
+
+    /**
+     * Default minor version number. Defaults to 1
+     */
     public static final int MINOR = 1;
+
+    /**
+     * Default patch version number. Defaults to 0
+     */
     public static final int PATCH = 0;
 
     private static final Version INSTANCE = new Version(MAJOR, MINOR, PATCH);
 
+    /**
+     * @return Returns an instance of the version
+     */
     public static Version getInstance() { return INSTANCE; }
 
     private final int major;
@@ -29,6 +46,10 @@ public class Version implements Comparable<Version> {
         this.patch = patch;
     }
 
+    /**
+     * Returns the Version in string representation in the format: Major.Minor.Patch.
+     * @return The Version converted to a string
+     */
     public String getVersionString() {
         return String.format("%d.%d.%d", MAJOR, MINOR, PATCH);
     }
@@ -38,6 +59,13 @@ public class Version implements Comparable<Version> {
         return getVersionString();
     }
 
+    /**
+     * Returns a new Version class from the given version string.
+     * Will throw an exception if it cannot convert.
+     *
+     * @param versionString The version string to convert
+     * @return The Version class created from the string
+     */
     public static Version fromString(final String versionString) {
         if (versionString == null) {
             throw new IllegalArgumentException("Cannot extract version from null string");

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/AccessDeniedException.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/AccessDeniedException.java
@@ -1,6 +1,12 @@
 package software.amazon.awssdk.eventstreamrpc.model;
 
+/**
+ * Thrown when an access denied exception occurs
+ */
 public class AccessDeniedException extends EventStreamOperationError {
+    /**
+    * The error code associated with a access denied exception
+    */
     public static final String ERROR_CODE = "aws#AccessDenied";
 
     /**
@@ -9,13 +15,21 @@ public class AccessDeniedException extends EventStreamOperationError {
      *
      * Do not overexpose reason or logic for AccessDenied. Prefer internal logging
      *
-     * @param serviceName
-     * @param message
+     * @param serviceName The name of the service that caused the exception
+     * @param message The message to associate with the exception
      */
     public AccessDeniedException(String serviceName, String message) {
         super(serviceName, ERROR_CODE, message);
     }
 
+    /**
+     * Message constructor may reveal what operation or resource was denied access
+     * or the principal/authN that was rejected
+     *
+     * Do not overexpose reason or logic for AccessDenied. Prefer internal logging
+     *
+     * @param serviceName The name of the service that caused the exception
+     */
     public AccessDeniedException(String serviceName) {
         super(serviceName, ERROR_CODE, "AccessDenied");
     }
@@ -23,7 +37,7 @@ public class AccessDeniedException extends EventStreamOperationError {
     /**
      * Returns the named model type. May be used for a header.
      *
-     * @return
+     * @return The named model type
      */
     @Override
     public String getApplicationModelType() {

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamError.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamError.java
@@ -23,11 +23,11 @@ public class EventStreamError
     private final MessageType messageType;
 
     /**
-     * Put
+     * Creates a new EventStreamError
      * @param headers currently unusued, but likely a useful element for output
-     * @param payload
-     * @param messageType
-     * @return
+     * @param payload The payload to associated with the EventStreamError
+     * @param messageType The message type to associate with the EventStreamError
+     * @return A new EventStreamError
      */
     public static EventStreamError create(final List<Header> headers, final byte[] payload, final MessageType messageType) {
         try {
@@ -39,22 +39,40 @@ public class EventStreamError
         }
     }
 
+    /**
+     * Creates a new EventStream error with only a message
+     * @param message The message to associate with the EventStreamError
+     */
     public EventStreamError(String message) {
         super(message);
         this.messageType = null;
         this.headers = null;
     }
 
+    /**
+     * Creates a new EventStreamError with a message, headers, and message type
+     * @param message The message to associate with the EventStreamError
+     * @param headers Headers to associate with the EventStreamError
+     * @param messageType The message type to associate with the EventStreamError
+     */
     public EventStreamError(String message, List<Header> headers, MessageType messageType) {
         super(message);
         this.messageType = messageType;
         this.headers = headers;
     }
 
+    /**
+     * Returns the headers associated with the EventStreamError
+     * @return the headers associated with the EventStreamError
+     */
     public List<Header> getMessageHeaders() {
         return headers;
     }
 
+    /**
+     * Returns the message type associated with the EventStreamError
+     * @return the message type associated with the EventStreamError
+     */
     public MessageType getMessageType() {
         return messageType;
     }

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamJsonMessage.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamJsonMessage.java
@@ -15,8 +15,8 @@ public interface EventStreamJsonMessage {
      * with final implementations for serialization/deserialization. Or better yet, rework
      * how it works
      *
-     * @param gson
-     * @return
+     * @param gson The GSON to convert to a JSON payload
+     * @return The GSON converted to a JSON payload
      */
     default byte[] toPayload(final Gson gson) {
         final String payloadString = gson.toJson(this);
@@ -26,6 +26,12 @@ public interface EventStreamJsonMessage {
         return payloadString.getBytes(StandardCharsets.UTF_8);
     }
 
+    /**
+     * Converts the given GSON and payload into a EventStreamJsonMessage
+     * @param gson The GSON to convert
+     * @param payload The payload to convert
+     * @return A EventStreamJsonMessage
+     */
     default EventStreamJsonMessage fromJson(final Gson gson, byte[] payload) {
         final String payloadString = new String(payload, StandardCharsets.UTF_8);
         if (payloadString.equals("null")) {
@@ -41,9 +47,13 @@ public interface EventStreamJsonMessage {
 
     /**
      * Returns the named model type. May be used for a header.
-     * @return
+     * @return the named model type
      */
     public String getApplicationModelType();
 
+    /**
+     * Returns whether the EventStreamJsonMessage is void
+     * @return True if the EventStreamJsonMessage is void
+     */
     default boolean isVoid() { return false; }
 }

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamOperationError.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamOperationError.java
@@ -25,6 +25,12 @@ public abstract class EventStreamOperationError
     @Expose(serialize = true, deserialize = true)
     private final String _errorCode;
 
+    /**
+     * Creates a new EventStreamOperationError from the given service name, error code, and message
+     * @param serviceName The service that caused the error
+     * @param errorCode The error code associated with the error
+     * @param message The message to show alongside the error
+     */
     public EventStreamOperationError(final String serviceName, final String errorCode, final String message) {
         super(String.format("%s[%s]: %s", errorCode, serviceName, message));
         this._service = serviceName;
@@ -32,13 +38,17 @@ public abstract class EventStreamOperationError
         this._message = message;
     }
 
+    /**
+     * Returns the name of the service that caused the error
+     * @return the name of the service that caused the error
+     */
     public String getService() {
         return _service;
     }
 
     /**
      * Likely overridden by a specific field defined in service-operation model
-     * @return
+     * @return The message associated with the error
      */
     public String getMessage() {
         return _message;
@@ -46,7 +56,7 @@ public abstract class EventStreamOperationError
 
     /**
      * Likely subclasses will have a more limited set of valid error codes
-     * @return
+     * @return The error code associated with the error
      */
     public String getErrorCode() { return _errorCode; }
 }

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/InternalServerException.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/InternalServerException.java
@@ -1,8 +1,18 @@
 package software.amazon.awssdk.eventstreamrpc.model;
 
+/**
+ * Thrown when a internal server exception occurs
+ */
 public class InternalServerException extends EventStreamOperationError {
+    /**
+     * The error code associated with a internal server exception
+     */
     public static final String ERROR_CODE = "aws#InternalServerException";
 
+    /**
+     * Creates a new internal server exception from the given service name
+     * @param serviceName The name of the service that caused the exception
+     */
     public InternalServerException(String serviceName) {
         super(serviceName, ERROR_CODE, "An internal server exception has occurred.");
     }

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/UnsupportedOperationException.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/UnsupportedOperationException.java
@@ -1,8 +1,19 @@
 package software.amazon.awssdk.eventstreamrpc.model;
 
+/**
+ * Thrown when an unsupported operation exception occurs
+ */
 public class UnsupportedOperationException extends EventStreamOperationError {
+    /**
+     * The error code associated with a unsupported operation exception
+     */
     public static final String ERROR_CODE = "aws#UnsupportedOperation";
 
+    /**
+     * Creates a new UnsupportedOperationException from the given service and operation names
+     * @param serviceName The name of the service that caused the exception
+     * @param operationName The name of the operation that caused the exception
+     */
     public UnsupportedOperationException(String serviceName, String operationName) {
         super(serviceName, ERROR_CODE, "UnsupportedOperation: " + operationName);
     }
@@ -10,7 +21,7 @@ public class UnsupportedOperationException extends EventStreamOperationError {
     /**
      * Returns the named model type. May be used for a header.
      *
-     * @return
+     * @return the named model type
      */
     @Override
     public String getApplicationModelType() {

--- a/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/ValidationException.java
+++ b/sdk/greengrass/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/ValidationException.java
@@ -1,8 +1,19 @@
 package software.amazon.awssdk.eventstreamrpc.model;
 
+/**
+ * Thrown when a validation exception occurs
+ */
 public class ValidationException extends EventStreamOperationError {
+    /**
+     * The error code associated with a validation exception
+     */
     public static final String ERROR_CODE = "aws#ValidationException";
 
+    /**
+     * Creates a new ValidationException with the given service name and message
+     * @param serviceName The name of the service that caused the exception
+     * @param message The reason for the exception
+     */
     public ValidationException(String serviceName, String message) {
         super(serviceName, ERROR_CODE, message);
     }
@@ -10,7 +21,7 @@ public class ValidationException extends EventStreamOperationError {
     /**
      * Returns the named model type. May be used for a header.
      *
-     * @return
+     * @return the named model type
      */
     @Override
     public String getApplicationModelType() {

--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationData.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationData.java
@@ -10,7 +10,7 @@ public interface AuthenticationData {
      * string must be appropriate for audit logs and enable tracing specific callers/clients
      * to relevant decision and operations executed
      *
-     * @return
+     * @return A human readable string for who the identity of the client/caller is
      */
     public String getIdentityLabel();
 }

--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/Authorization.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/Authorization.java
@@ -3,7 +3,6 @@ package software.amazon.awssdk.eventstreamrpc;
 /**
  * Authorization decision object contains the decision in general
  * and the authentication data along with it.
- *
  */
 public enum Authorization {
     ACCEPT,

--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/DebugLoggingOperationHandler.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/DebugLoggingOperationHandler.java
@@ -15,6 +15,11 @@ public class DebugLoggingOperationHandler extends OperationContinuationHandler
     private static Logger LOGGER = LoggerFactory.getLogger(DebugLoggingOperationHandler.class);
     private final OperationModelContext operationModelContext;
 
+    /**
+     * Constructs a new DebugLoggingOperationHandler from the given model and continuation handler contexts
+     * @param modelContext The model context
+     * @param context The continuation handler model context
+     */
     public DebugLoggingOperationHandler(final OperationModelContext modelContext, final OperationContinuationHandlerContext context) {
         super(context);
         this.operationModelContext = modelContext;

--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceHandler.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceHandler.java
@@ -2,10 +2,16 @@ package software.amazon.awssdk.eventstreamrpc;
 
 import java.util.Collection;
 
+/**
+ * The EventStream RPC Service Handler
+ */
 public abstract class EventStreamRPCServiceHandler implements OperationContinuationHandlerFactory {
     private AuthenticationHandler authenticationHandler;
     private AuthorizationHandler authorizationHandler;
 
+    /**
+     * Constructs a new EventStreamRPCServiceHandler
+     */
     public EventStreamRPCServiceHandler() {
         authorizationHandler = null;
     }
@@ -22,7 +28,7 @@ public abstract class EventStreamRPCServiceHandler implements OperationContinuat
 
     /**
      * TODO: How may we want to protect this from being re-assigned after service creation?
-     * @param handler
+     * @param handler Sets the authorization handler
      */
     public void setAuthorizationHandler(final AuthorizationHandler handler) {
         this.authorizationHandler = handler;
@@ -30,8 +36,7 @@ public abstract class EventStreamRPCServiceHandler implements OperationContinuat
 
     /**
      * Use this to determine if the connection should be accepted or rejected for this service
-     *
-     * @return
+     * @return Returns the authorization handler
      */
     public AuthorizationHandler getAuthorizationHandler() {
         return authorizationHandler;
@@ -44,7 +49,7 @@ public abstract class EventStreamRPCServiceHandler implements OperationContinuat
 
     /**
      * Pulls caller/client identity when server connection occurs
-     * @return
+     * @return Returns the authentication handler
      */
     public AuthenticationHandler getAuthenticationHandler() {
         return authenticationHandler;
@@ -52,7 +57,7 @@ public abstract class EventStreamRPCServiceHandler implements OperationContinuat
 
     /**
      * TODO: How may we want to protect this from being re-assigned after service creation?
-     * @param authenticationHandler
+     * @param authenticationHandler Sets the authentication handler
      */
     public void setAuthenticationHandler(AuthenticationHandler authenticationHandler) {
         this.authenticationHandler = authenticationHandler;

--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidServiceConfigurationException.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidServiceConfigurationException.java
@@ -1,14 +1,30 @@
 package software.amazon.awssdk.eventstreamrpc;
 
+/**
+ * Thrown when a invalid service configuration exception occurs
+ */
 public class InvalidServiceConfigurationException extends RuntimeException {
+    /**
+     * Constructs a new InvalidServiceConfigurationException with the given message
+     * @param msg The message to associate with the exception
+     */
     public InvalidServiceConfigurationException(String msg) {
         super(msg);
     }
 
+    /**
+     * Constructs a new InvalidServiceConfigurationException with the given message and cause
+     * @param msg The message to associate with the exception
+     * @param cause The cause to associate with the exception
+     */
     public InvalidServiceConfigurationException(String msg, Throwable cause) {
         super(msg, cause);
     }
 
+    /**
+     * Constructs a new InvalidServiceConfigurationException with the given cause
+     * @param cause The cause to associate with the exception
+     */
     public InvalidServiceConfigurationException(Throwable cause) {
         super(cause);
     }

--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/IpcServer.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/IpcServer.java
@@ -12,8 +12,18 @@ import software.amazon.awssdk.crt.io.TlsContextOptions;
 final public class IpcServer extends RpcServer {
     private static final Logger LOGGER = LoggerFactory.getLogger(IpcServer.class);
 
+    /**
+     * DEPRECATION WARNING: Stop using this class. Use RpcServer instead
+     * @param eventLoopGroup The EventLoopGroup to use
+     * @param socketOptions The SocketOptions to use
+     * @param tlsContextOptions The TlsContextOptions to use
+     * @param hostname The host name to use
+     * @param port The port to use
+     * @param serviceHandler The service handler to use
+     */
     public IpcServer(EventLoopGroup eventLoopGroup, SocketOptions socketOptions, TlsContextOptions tlsContextOptions, String hostname, int port, EventStreamRPCServiceHandler serviceHandler) {
         super(eventLoopGroup, socketOptions, tlsContextOptions, hostname, port, serviceHandler);
         LOGGER.warn("IpcServer class is DEPRECATED. Use RpcServer");
     }
 }
+

--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerContext.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerContext.java
@@ -16,6 +16,12 @@ public class OperationContinuationHandlerContext {
     private final ServerConnectionContinuation continuation;
     private final AuthenticationData authenticationData;
 
+    /**
+     * Creates a new OperationContinuationHandlerContext
+     * @param connection The connection to associate with the OperationContinuationHandlerContext
+     * @param continuation The continuation to associate with the OperationContinuationHandlerContext
+     * @param authenticationData The authentication data to associate with the OperationContinuationHandlerContext
+     */
     public OperationContinuationHandlerContext(final ServerConnection connection,
            final ServerConnectionContinuation continuation,
            final AuthenticationData authenticationData) {
@@ -24,14 +30,26 @@ public class OperationContinuationHandlerContext {
         this.authenticationData = authenticationData;
     }
 
+    /**
+     * Returns the connection associated with the OperationContinuationHandlerContext
+     * @return the connection associated with the OperationContinuationHandlerContext
+     */
     public ServerConnection getServerConnection() {
         return serverConnection;
     }
 
+    /**
+     * Returns the continuation associated with the OperationContinuationHandlerContext
+     * @return the continuation associated with the OperationContinuationHandlerContext
+     */
     public ServerConnectionContinuation getContinuation() {
         return continuation;
     }
 
+    /**
+     * Returns the authentication data associated with the OperationContinuationHandlerContext
+     * @return the authentication data associated with the OperationContinuationHandlerContext
+     */
     public AuthenticationData getAuthenticationData() {
         return authenticationData;
     }

--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerFactory.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerFactory.java
@@ -14,8 +14,10 @@ public interface OperationContinuationHandlerFactory {
     Collection<String> getAllOperations();
     boolean hasHandlerForOperation(String operation);
 
-    //this may not be a good use of a default method impl as implementers can override it
-    //also InvalidServiceConfigurationException is a needed exception to be thrown from IpcServer
+    /**
+     * this may not be a good use of a default method impl as implementers can override it
+     * also InvalidServiceConfigurationException is a needed exception to be thrown from IpcServer
+     */
     default void validateAllOperationsSet() {
         if (!getAllOperations().stream().allMatch(op -> hasHandlerForOperation(op))) {
             String unmappedOperations = getAllOperations().stream()

--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/RpcServer.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/RpcServer.java
@@ -18,6 +18,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+/**
+ * The RPCServer implementation
+ */
 public class RpcServer implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(RpcServer.class);
 
@@ -34,6 +37,15 @@ public class RpcServer implements AutoCloseable {
     private AtomicBoolean serverRunning;
     private int boundPort = -1;
 
+    /**
+     * Creates a new RPC Server
+     * @param eventLoopGroup The EventLoopGroup to use in the RPC server
+     * @param socketOptions The SocketOptions to use in the RPC server
+     * @param tlsContextOptions The TlsContextOptions to use in the RPC server
+     * @param hostname The hostname to use in the RPC server
+     * @param port The port to use in the RPC server
+     * @param serviceHandler The ServceHandler to use in the RPC server
+     */
     public RpcServer(EventLoopGroup eventLoopGroup, SocketOptions socketOptions, TlsContextOptions tlsContextOptions, String hostname, int port, EventStreamRPCServiceHandler serviceHandler) {
         this.eventLoopGroup = eventLoopGroup;
         this.socketOptions = socketOptions;
@@ -90,6 +102,8 @@ public class RpcServer implements AutoCloseable {
 
     /**
      * Stops running server and allows the caller to wait on a CompletableFuture
+     *
+     * @return A future that is completed when the server stops
      */
     public CompletableFuture<Void> stopServer() {
         if (serverRunning.compareAndSet(true, false)) {

--- a/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/ServiceOperationMappingContinuationHandler.java
+++ b/sdk/greengrass/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/ServiceOperationMappingContinuationHandler.java
@@ -19,11 +19,19 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * Handler for Service Operation Continuation Mapping
+ */
 public class ServiceOperationMappingContinuationHandler extends ServerConnectionHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceOperationMappingContinuationHandler.class);
     private final EventStreamRPCServiceHandler serviceHandler;
     private AuthenticationData authenticationData;  //should only be set once after AuthN
 
+    /**
+     * Constructs a new ServiceOperationMappingContinuationHandler
+     * @param serverConnection The ServerConnection to use
+     * @param handler The EventStreamRPCServiceHandler to use
+     */
     public ServiceOperationMappingContinuationHandler(final ServerConnection serverConnection, final EventStreamRPCServiceHandler handler) {
         super(serverConnection);
         this.serviceHandler = handler;
@@ -57,8 +65,8 @@ public class ServiceOperationMappingContinuationHandler extends ServerConnection
 
     /**
      * Post: authenticationData should not be null
-     * @param headers
-     * @param payload
+     * @param headers The connection request headers
+     * @param payload The connection request payload
      */
     protected void onConnectRequest(List<Header> headers, byte[] payload) {
         final int[] responseMessageFlag = { 0 };


### PR DESCRIPTION
*Description of changes:*

Adds documentation to all of the `event-stream-rpc` classes, removing many JavaDoc warnings.

______

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
