### PR TITLE
Fix Windows and Mac CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         cache: maven
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
-        mvn install -Dmaven.test.skip=true
+        mvn install
     - name: Running samples in CI setup
       run: |
         python3 -m pip install boto3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Running samples in CI setup
       run: |
         python -m pip install boto3
-        mvn install -Dmaven.test.skip
+        mvn install -DskipTests
     - name: configure AWS credentials (PubSub)
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,10 @@ jobs:
         cache: maven
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
-        python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+        mvn install
     - name: Running samples in CI setup
       run: |
         python -m pip install boto3
-        mvn install -DskipTests
     - name: configure AWS credentials (PubSub)
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -121,13 +119,10 @@ jobs:
         cache: maven
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
-        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
-        chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+        mvn install -Dmaven.test.skip=true
     - name: Running samples in CI setup
       run: |
         python3 -m pip install boto3
-        mvn install -Dmaven.test.skip=true
     - name: configure AWS credentials (PubSub)
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
     - name: Running samples in CI setup
       run: |
         python -m pip install boto3
+        mvn install -Dmaven.test.skip=true
     - name: configure AWS credentials (PubSub)
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -126,6 +127,7 @@ jobs:
     - name: Running samples in CI setup
       run: |
         python3 -m pip install boto3
+        mvn install -Dmaven.test.skip=true
     - name: configure AWS credentials (PubSub)
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Running samples in CI setup
       run: |
         python -m pip install boto3
-        mvn install -Dmaven.test.skip=true
+        mvn install -Dmaven.test.skip
     - name: configure AWS credentials (PubSub)
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/README.md
+++ b/README.md
@@ -170,3 +170,4 @@ We need your help in making this SDK great. Please participate in the community 
 ## License
 
 This library is licensed under the Apache 2.0 License.
+


### PR DESCRIPTION
*Description of changes:*

Something changed with how GitHub actions or the builder was installing the SDK. Now it compiles the SDK, but does not automatically install it. To fix this, we just have to add an extra step to install the SDK so the samples in CI can run again.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
