### PR TITLE
Custom auth websocket fix

### DIFF
--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
@@ -578,9 +578,12 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
         if (password != null) {
             config.setPassword(password);
         }
-        config.setPort(443);
-        tlsOptions.alpnList.clear();
-        tlsOptions.alpnList.add("mqtt");
+
+        if (config.getUseWebsockets() == false) {
+            config.setPort(443);
+            tlsOptions.alpnList.clear();
+            tlsOptions.alpnList.add("mqtt");
+        }
 
         return this;
     }
@@ -616,15 +619,6 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
             if (isUsingCustomAuthorizer == true) {
                 if (config.getPort() != 443) {
                     Log.log(LogLevel.Warn, LogSubject.MqttClient,"Attempting to connect to authorizer with unsupported port. Port is not 443...");
-                }
-                if (tlsOptions.alpnList.size() == 1) {
-                    if (tlsOptions.alpnList.get(0) != "mqtt") {
-                        tlsOptions.alpnList.clear();
-                        tlsOptions.alpnList.add("mqtt");
-                    }
-                } else {
-                    tlsOptions.alpnList.clear();
-                    tlsOptions.alpnList.add("mqtt");
                 }
             }
 


### PR DESCRIPTION
*Description of changes:*

Fixes custom authorizer not being able to connect when used with Websockets.

The issue is that the custom authorizer implementation on native forces a `alpn_list` of `mqtt`, causing custom authorizer connections via websockets to not be able to connect. Tested locally and with this fix, both direct MQTT custom authorizer connections and websocket custom authorizer connections work as expected.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
