### PR TITLE
Fix to pipeline

### DIFF
--- a/codebuild/cd/deploy-snapshot.yml
+++ b/codebuild/cd/deploy-snapshot.yml
@@ -20,6 +20,10 @@ phases:
 
   pre_build:
     commands:
+      # Will avoid "gpg: signing failed: Inappropriate ioctl for device" errors
+      # Reference: https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG_002dAGENT.html
+      - export GPG_TTY=$(tty)
+
       - cd $CODEBUILD_SRC_DIR/aws-iot-device-sdk-java-v2
       - export PKG_VERSION=$(cat $CODEBUILD_SRC_DIR/VERSION)
 


### PR DESCRIPTION
*Description of changes:*

Using a newer container means we need to pass `export GPG_TTY=$(tty)` to avoid getting `gpg: signing failed: Inappropriate ioctl for device` errors. This was not an issue before because we were using an old version.

Reference for fix: https://unix.stackexchange.com/questions/257061/gentoo-linux-gpg-encrypts-properly-a-file-passed-through-parameter-but-throws-i/257065#257065

_______________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
