### PR TITLE
Mqtt311 to mqtt5 builder

### DIFF
--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
@@ -309,16 +309,16 @@ public class AwsIotMqtt5ClientBuilder extends software.amazon.awssdk.crt.CrtReso
     }
 
     /**
-     * Creates a new MQTT5 client builder using a MqttConnectionConfig. This does NOT support all MqttConnectionConfig options and will throw
+     * Creates a new MQTT5 client builder using a MqttConnectionConfig.
+     *
+     * This does NOT support all MqttConnectionConfig options and will throw
      * an exception should it encounter options it does not support.
      *
      * Known unsupported options/cases:
-     * - Custom Authorizer: Will not be properly detected
-     * - Websockets: Not supported and will throw an exception
-     * - Will Message: Not supported and will throw an exception
-     * - Callbacks: Connection callbacks are not supported and will be ignored
-     *
-     * ALSO: This does NOT setup the callbacks nor can it detect Custom Authorizer usage.
+     * <p>- <b>Custom Authorizer</b>: Will not be properly detected nor setup
+     * <p>- <b>Websockets</b>: Is not supported and will throw an exception
+     * <p>- <b>Will Message</b>: Is not supported and will throw an exception
+     * <p>- <b>All Callbacks</b>: Connection callbacks are not supported and will be ignored
      *
      * @param mqtt311Config The MqttConnectionConfig to create a MQTT5 client builder from
      * @param tlsOptions The TLS options to use alongside the MqttConnectionConfig
@@ -327,7 +327,13 @@ public class AwsIotMqtt5ClientBuilder extends software.amazon.awssdk.crt.CrtReso
      */
     public static AwsIotMqtt5ClientBuilder newMqttBuilderFromMqtt311ConnectionConfig(MqttConnectionConfig mqtt311Config, TlsContextOptions tlsOptions) throws Exception {
 
-        // We'll blindly assume that you have it setup correctly.
+        if (mqtt311Config.getEndpoint() == null) {
+            throw new Exception("MQTT311 to MQTT5 builder requires MQTT311 to have a endpoint set");
+        }
+        if (tlsOptions == null) {
+            throw new Exception("MQTT311 to MQTT5 builder requires MQTT311 to TLS options passed");
+        }
+
         AwsIotMqtt5ClientBuilder builder = new AwsIotMqtt5ClientBuilder(mqtt311Config.getEndpoint(), (long)mqtt311Config.getPort(), tlsOptions);
         if (tlsOptions.isAlpnSupported()) {
             builder.configTls.withAlpnList("x-amzn-mqtt-ca");
@@ -337,7 +343,7 @@ public class AwsIotMqtt5ClientBuilder extends software.amazon.awssdk.crt.CrtReso
             throw new Exception("MQTT311 to MQTT5 builder does not support MQTT311 websockets");
         }
         if (mqtt311Config.getWillMessage() != null) {
-            throw new Exception("MQTT311 to MQTT5 builder does not support MQTT311 will messages");
+            throw new Exception("MQTT311 to MQTT5 builder does not support MQTT311 Will messages");
         }
 
         ConnectPacketBuilder connectPacket = new ConnectPacketBuilder();

--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
@@ -341,10 +341,16 @@ public class AwsIotMqtt5ClientBuilder extends software.amazon.awssdk.crt.CrtReso
         }
 
         ConnectPacketBuilder connectPacket = new ConnectPacketBuilder();
-        connectPacket.withClientId(mqtt311Config.getClientId());
+        if (mqtt311Config.getClientId() != null) {
+            connectPacket.withClientId(mqtt311Config.getClientId());
+        }
         connectPacket.withKeepAliveIntervalSeconds((long)mqtt311Config.getKeepAliveSecs());
-        connectPacket.withUsername(mqtt311Config.getUsername());
-        connectPacket.withPassword(mqtt311Config.getPassword().getBytes());
+        if (mqtt311Config.getUsername() != null) {
+            connectPacket.withUsername(mqtt311Config.getUsername());
+        }
+        if (mqtt311Config.getPassword() != null) {
+            connectPacket.withPassword(mqtt311Config.getPassword().getBytes());
+        }
         builder.withConnectProperties(connectPacket);
 
         builder.withHttpProxyOptions(mqtt311Config.getHttpProxyOptions());

--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.crt.io.TlsContextCustomKeyOperationOptions;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.crt.io.TlsContextPkcs11Options;
 import software.amazon.awssdk.crt.io.ExponentialBackoffRetryOptions.JitterMode;
+import software.amazon.awssdk.crt.mqtt.MqttConnectionConfig;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5Client;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5ClientOptions;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5WebsocketHandshakeTransformArgs;
@@ -304,6 +305,55 @@ public class AwsIotMqtt5ClientBuilder extends software.amazon.awssdk.crt.CrtReso
         if (TlsContextOptions.isAlpnSupported()) {
             builder.configTls.withAlpnList("x-amzn-mqtt-ca");
         }
+        return builder;
+    }
+
+    /**
+     * Creates a new MQTT5 client builder using a MqttConnectionConfig. This does NOT support all MqttConnectionConfig options and will throw
+     * an exception should it encounter options it does not support.
+     *
+     * Known unsupported options/cases:
+     * - Custom Authorizer: Will not be properly detected
+     * - Websockets: Not supported and will throw an exception
+     * - Will Message: Not supported and will throw an exception
+     * - Callbacks: Connection callbacks are not supported and will be ignored
+     *
+     * ALSO: This does NOT setup the callbacks nor can it detect Custom Authorizer usage.
+     *
+     * @param mqtt311Config The MqttConnectionConfig to create a MQTT5 client builder from
+     * @param tlsOptions The TLS options to use alongside the MqttConnectionConfig
+     * @return A new AwsIotMqtt5ClientBuilder
+     * @throws Exception If an unsupported option is passed
+     */
+    public static AwsIotMqtt5ClientBuilder newMqttBuilderFromMqtt311ConnectionConfig(MqttConnectionConfig mqtt311Config, TlsContextOptions tlsOptions) throws Exception {
+
+        // We'll blindly assume that you have it setup correctly.
+        AwsIotMqtt5ClientBuilder builder = new AwsIotMqtt5ClientBuilder(mqtt311Config.getEndpoint(), (long)mqtt311Config.getPort(), tlsOptions);
+        if (tlsOptions.isAlpnSupported()) {
+            builder.configTls.withAlpnList("x-amzn-mqtt-ca");
+        }
+
+        if (mqtt311Config.getUseWebsockets() == true) {
+            throw new Exception("MQTT311 to MQTT5 builder does not support MQTT311 websockets");
+        }
+        if (mqtt311Config.getWillMessage() != null) {
+            throw new Exception("MQTT311 to MQTT5 builder does not support MQTT311 will messages");
+        }
+
+        ConnectPacketBuilder connectPacket = new ConnectPacketBuilder();
+        connectPacket.withClientId(mqtt311Config.getClientId());
+        connectPacket.withKeepAliveIntervalSeconds((long)mqtt311Config.getKeepAliveSecs());
+        connectPacket.withUsername(mqtt311Config.getUsername());
+        connectPacket.withPassword(mqtt311Config.getPassword().getBytes());
+        builder.withConnectProperties(connectPacket);
+
+        builder.withHttpProxyOptions(mqtt311Config.getHttpProxyOptions());
+        builder.withMaxReconnectDelayMs(mqtt311Config.getMaxReconnectTimeoutSecs() * 1000); // Seconds to milliseconds
+        builder.withMinReconnectDelayMs(mqtt311Config.getMinReconnectTimeoutSecs() * 1000); // Seconds to milliseconds
+        builder.withPingTimeoutMs((long)mqtt311Config.getPingTimeoutMs());
+        builder.withAckTimeoutSeconds((long)mqtt311Config.getProtocolOperationTimeoutMs() * 1000); // Seconds to milliseconds
+        builder.withSocketOptions(mqtt311Config.getSocketOptions());
+
         return builder;
     }
 

--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
@@ -609,6 +609,18 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
     }
 
     /**
+     * Converts a AwsIotMqttConnectionBuilder to a AwsIotMqtt5ClientBuilder, converting as much as possible.
+     * See AwsIotMqtt5ClientBuilder.newMqttBuilderFromMqtt311ConnectionConfig for more information on what can
+     * be converted, the quirks, etc.
+     *
+     * @return A AwsIotMqtt5ClientBuilder using AwsIotMqttConnectionBuilder settings
+     * @throws Exception If an unsupported option is present
+     */
+    public AwsIotMqtt5ClientBuilder toAwsIotMqtt5ClientBuilder() throws Exception {
+        return AwsIotMqtt5ClientBuilder.newMqttBuilderFromMqtt311ConnectionConfig(config, tlsOptions);
+    }
+
+    /**
      * Builds a new mqtt connection from the configuration stored in the builder.  Because some objects are created
      * lazily, certain properties should not be modified after this is first invoked (tls options, bootstrap).
      *

--- a/sdk/tests/mqtt5/Mqtt5BuilderTest.java
+++ b/sdk/tests/mqtt5/Mqtt5BuilderTest.java
@@ -413,7 +413,7 @@ public class Mqtt5BuilderTest {
         try {
             builder = mqtt311Builder.toAwsIotMqtt5ClientBuilder();
         } catch (Exception ex) {
-            fail("Exception occurred making AwsIotMqtt5ClientBuilder from MQTT311 config!");
+            fail("Exception occurred making AwsIotMqtt5ClientBuilder from MQTT311 config! Exception: " + ex.getMessage());
         }
         // Close the MQTT311 builder
         mqtt311Builder.close();

--- a/sdk/tests/mqtt5/Mqtt5BuilderTest.java
+++ b/sdk/tests/mqtt5/Mqtt5BuilderTest.java
@@ -405,10 +405,16 @@ public class Mqtt5BuilderTest {
         assumeTrue(mqtt5IoTCoreKeyPath != null);
 
         // Make a simple MQTT311 builder
-        AwsIotMqttConnectionBuilder mqtt311Builder = AwsIotMqttConnectionBuilder.newMtlsBuilderFromPath(mqtt5IoTCoreCertificatePath, mqtt5IoTCoreKeyPath)
+        AwsIotMqttConnectionBuilder mqtt311Builder = AwsIotMqttConnectionBuilder.newMtlsBuilderFromPath(
+            mqtt5IoTCoreCertificatePath, mqtt5IoTCoreKeyPath);
         mqtt311Builder.withEndpoint(mqtt5IoTCoreHost);
+        AwsIotMqtt5ClientBuilder builder = null;
         // CONVERT
-        AwsIotMqtt5ClientBuilder builder = mqtt311Builder.toAwsIotMqtt5ClientBuilder();
+        try {
+            builder = mqtt311Builder.toAwsIotMqtt5ClientBuilder();
+        } catch (Exception ex) {
+            fail("Exception occurred making AwsIotMqtt5ClientBuilder from MQTT311 config!");
+        }
         // Close the MQTT311 builder
         mqtt311Builder.close();
 

--- a/sdk/tests/mqtt5/Mqtt5BuilderTest.java
+++ b/sdk/tests/mqtt5/Mqtt5BuilderTest.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.crt.mqtt5.packets.PublishPacket;
 import software.amazon.awssdk.crt.mqtt5.packets.SubscribePacket;
 import software.amazon.awssdk.crt.mqtt5.packets.UnsubscribePacket;
 import software.amazon.awssdk.iot.AwsIotMqtt5ClientBuilder;
+import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
 public class Mqtt5BuilderTest {
 
@@ -382,6 +383,34 @@ public class Mqtt5BuilderTest {
 
         AwsIotMqtt5ClientBuilder builder = AwsIotMqtt5ClientBuilder.newWebsocketMqttBuilderWithCustomAuth(
             mqtt5IoTCoreHost, customAuthConfig);
+
+        LifecycleEvents_Futured lifecycleEvents = new LifecycleEvents_Futured();
+        builder.withLifeCycleEvents(lifecycleEvents);
+
+        PublishEvents_Futured publishEvents = new PublishEvents_Futured();
+        builder.withPublishEvents(publishEvents);
+
+        Mqtt5Client client = builder.build();
+        TestSubPubUnsub(client, lifecycleEvents, publishEvents);
+        client.close();
+        builder.close();
+    }
+
+    /* MQTT311 builder to MQTT5 builder - simple direct connection */
+    @Test
+    public void ConnIoT_DirectConnect_MQTT311_to_MQTT5_UC1()
+    {
+        assumeTrue(mqtt5IoTCoreHost != null);
+        assumeTrue(mqtt5IoTCoreCertificatePath != null);
+        assumeTrue(mqtt5IoTCoreKeyPath != null);
+
+        // Make a simple MQTT311 builder
+        AwsIotMqttConnectionBuilder mqtt311Builder = AwsIotMqttConnectionBuilder.newMtlsBuilderFromPath(mqtt5IoTCoreCertificatePath, mqtt5IoTCoreKeyPath)
+        mqtt311Builder.withEndpoint(mqtt5IoTCoreHost);
+        // CONVERT
+        AwsIotMqtt5ClientBuilder builder = mqtt311Builder.toAwsIotMqtt5ClientBuilder();
+        // Close the MQTT311 builder
+        mqtt311Builder.close();
 
         LifecycleEvents_Futured lifecycleEvents = new LifecycleEvents_Futured();
         builder.withLifeCycleEvents(lifecycleEvents);


### PR DESCRIPTION
*Description of changes:*

Adds function to MQTT311 IoT builder to convert it (as best it can) to a MQTT5 builder. Does not support all properties but it does a best-effort attempt at converting.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
