### PR TITLE
Add Greengrass IPC sample to Java SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>samples/CustomAuthorizerConnect</module>
         <module>samples/JavaKeystoreConnect</module>
         <module>samples/Greengrass</module>
+        <module>samples/GreengrassIPC</module>
         <module>samples/Jobs</module>
         <module>samples/PubSubStress</module>
         <module>samples/CustomKeyOpsPubSub</module>

--- a/samples/GreengrassIPC/pom.xml
+++ b/samples/GreengrassIPC/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
+    <artifactId>GreengrassIPC</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Java bindings for the AWS IoT Core Service</description>
+    <url>https://github.com/awslabs/aws-iot-device-sdk-java-v2</url>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <profiles>
+        <profile>
+            <id>latest-release</id>
+            <dependencies>
+                <dependency>
+                    <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
+                    <artifactId>aws-iot-device-sdk</artifactId>
+                    <version>1.11.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
+                    <artifactId>aws-iot-device-sdk</artifactId>
+                    <version>1.0.0-SNAPSHOT </version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/samples/GreengrassIPC/src/main/java/greengrass/GreengrassIPC.java
+++ b/samples/GreengrassIPC/src/main/java/greengrass/GreengrassIPC.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+/**
+ * This sample uses AWS IoT Greengrass V2 to publish messages from the Greengrass device to the
+ * AWS IoT MQTT broker.
+ *
+ * This sample can be deployed as a Greengrass V2 component and it will publish 10 MQTT messages
+ * over the course of 10 seconds. The IPC integration with Greengrass V2 allows this code to run
+ * without additional IoT certificates or secrets, because it directly communicates with the
+ * Greengrass core running on the device. As such, to run this sample you need Greengrass Core running.
+ *
+ * For more information, see the samples README.md file at:
+ * https://github.com/aws/aws-iot-device-sdk-python-v2/tree/main/samples
+ */
+
+package greengrass;
+
+import java.nio.charset.StandardCharsets;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClientV2;
+import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreRequest;
+import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreResponse;
+import software.amazon.awssdk.aws.greengrass.model.QOS;
+
+class GreengrassIPC {
+    // When run normally, we want to exit nicely even if something goes wrong
+    // When run from CI, we want to let an exception escape which in turn causes the
+    // exec:java task to return a non-zero exit code
+    static String ciPropValue = System.getProperty("aws.crt.ci");
+    static boolean isCI = ciPropValue != null && Boolean.valueOf(ciPropValue);
+
+    // Some constants for the payload data we send via IPC
+    static double payloadBatteryStateCharge = 42.5;
+    static double payloadLocationLongitude = 48.15743;
+    static double payloadLocationLatitude = 11.57549;
+    // The number of IPC messages to send
+    static int sampleMessageCount = 10;
+    static int sampleMessagesSent = 0;
+
+    /*
+    * When called during a CI run, throw an exception that will escape and fail the exec:java task
+    * When called otherwise, print what went wrong (if anything) and just continue (return from main)
+    */
+    static void onApplicationFailure(Throwable cause) {
+        if (isCI) {
+            throw new RuntimeException("BasicPubSub execution failure", cause);
+        } else if (cause != null) {
+            System.out.println("Exception encountered: " + cause.toString());
+        }
+    }
+
+    /**
+     * A simple helper function to print a message when running locally (will not print in CI)
+    */
+    static void logMessage(String message) {
+        if (!isCI) {
+            System.out.println(message);
+        }
+    }
+
+    /**
+     * A helper function to generate a JSON payload to send via IPC to simplify/separate sample code.
+    */
+    public static String getIpcPayloadString() {
+        // Get the current time as a formatted string
+        String timestamp = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH:mm:ss").format(LocalDateTime.now());
+        // Construct a JSON string with the data
+        StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        builder.append("\"timestamp\":\"" + timestamp + "\",");
+        builder.append("\"battery_state_of_charge\":" + payloadBatteryStateCharge + ",");
+        builder.append("\"location\": {");
+        builder.append("\"longitude\":" + payloadLocationLongitude + ",");
+        builder.append("\"latitude\":" + payloadLocationLatitude);
+        builder.append("}");
+        builder.append("}");
+        return builder.toString();
+    }
+
+    public static void main(String[] args) {
+        logMessage("Greengrass IPC sample start");
+
+        // Create the Greengrass IPC client
+        GreengrassCoreIPCClientV2 ipcClient = null;
+        try {
+            ipcClient = GreengrassCoreIPCClientV2.builder().build();
+        } catch (Exception ex) {
+            logMessage("Failed to create Greengrass IPC client!");
+            onApplicationFailure(ex);
+            System.exit(-1);
+        }
+        if (ipcClient == null) {
+            logMessage("Failed to create Greengrass IPC client!");
+            onApplicationFailure(new Throwable("Error - IPC client not initialized!"));
+            System.exit(-1);
+        }
+
+        // Create the topic name
+        String topicNameFromEnv = System.getenv("AWS_IOT_THING_NAME");
+        if (topicNameFromEnv == null) {
+            logMessage("Could not get IoT Thing name from AWS_IOT_THING_NAME. Using name 'TestThing'...");
+            topicNameFromEnv = "TestThing";
+        }
+        String topicName = String.format("my/iot/%s/telementry", topicNameFromEnv);
+
+        // Create the IPC request, except the payload. The payload will be created right before sending.
+        PublishToIoTCoreRequest publishRequest = new PublishToIoTCoreRequest();
+        publishRequest.setQos(QOS.AT_LEAST_ONCE);
+        publishRequest.setTopicName(topicName);
+
+        try {
+            logMessage("Will attempt to send " + sampleMessageCount + " IPC publishes to IoT Core");
+            while (sampleMessagesSent < sampleMessageCount) {
+                logMessage("Sending message " + sampleMessagesSent++ + "...");
+
+                // Get the new IPC payload
+                publishRequest.withPayload(getIpcPayloadString().getBytes(StandardCharsets.UTF_8));
+                CompletableFuture<PublishToIoTCoreResponse> publishFuture = ipcClient.publishToIoTCoreAsync(publishRequest);
+
+                // Try to send the IPC message
+                try {
+                    publishFuture.get(60, TimeUnit.SECONDS);
+                    logMessage("Successfully published IPC message to IoT Core");
+                } catch (Exception ex) {
+                    logMessage("Failed to publish IPC message to IoT Core");
+                }
+
+                // Sleep for a second
+                Thread.sleep(1000);
+            }
+            logMessage("All publishes sent. Finishing sample...");
+            ipcClient.close();
+
+        } catch (Exception ex) {
+            logMessage("Something in Greengrass IPC sample failed by throwing an exception! Shutting down sample...");
+            onApplicationFailure(ex);
+            try {
+                ipcClient.close();
+            } catch (Exception closeEx) {
+                onApplicationFailure(closeEx);
+            }
+            logMessage("Greengrass IPC sample finished with error");
+            System.exit(-1);
+        }
+
+         logMessage("Greengrass IPC sample finished");
+         System.exit(0);
+    }
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,7 +13,8 @@
 * [Shadow](#shadow)
 * [Jobs](#jobs)
 * [fleet provisioning](#fleet-provisioning)
-* [Greengrass](#greengrass-discovery)
+* [Greengrass Discovery](#greengrass-discovery)
+* [Greengrass IPC](#greengrass-ipc)
 * [MQTT5 PubSub](#mqtt5-pubsub)
 
 **Additional sample apps not described below:**
@@ -1011,6 +1012,90 @@ This sample is intended for use with the following tutorials in the AWS IoT Gree
 * [Connect and test client devices](https://docs.aws.amazon.com/greengrass/v2/developerguide/client-devices-tutorial.html) (Greengrass V2)
 * [Test client device communications](https://docs.aws.amazon.com/greengrass/v2/developerguide/test-client-device-communications.html) (Greengrass V2)
 * [Getting Started with AWS IoT Greengrass](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-gs.html) (Greengrass V1)
+
+## Greengrass IPC
+
+This sample uses [AWS IoT Greengrass V2](https://docs.aws.amazon.com/greengrass/index.html) to publish messages from the Greengrass device to the AWS IoT MQTT broker.
+
+This sample can be deployed as a Greengrass V2 component and it will publish 10 MQTT messages over the course of 10 seconds. The IPC integration with Greengrass V2 allows this code to run without additional IoT certificates or secrets, because it directly communicates with the Greengrass core running on the device. As such, to run this sample you need Greengrass Core running.
+
+source: `samples/GreengrassIPC`
+
+Some Greengrass references:
+
+* See this page for more information on Greengrass v2 components: https://docs.aws.amazon.com/greengrass/v2/developerguide/create-components.html
+* See this page for more information on IPC in Greengrass v2: https://docs.aws.amazon.com/greengrass/v2/developerguide/interprocess-communication.html
+* See this page for more information on how to make a local deployment: https://docs.aws.amazon.com/greengrass/v2/developerguide/test-components.html
+
+To run the sample, create a new AWS IoT Greengrass component and deploy it to your device with the following recipe snippet to allow your device to publish to AWS IoT Core:
+
+<details>
+
+```yaml
+  ---
+  RecipeFormatVersion: "2020-01-25"
+  ComponentName: "GreengrassIPC"
+  ComponentVersion: "1.0.0"
+  ComponentDescription: "IPC Greengrass sample."
+  ComponentPublisher: "<ComponentPublisher>"
+  ComponentConfiguration:
+  DefaultConfiguration:
+      accessControl:
+      aws.greengrass.ipc.mqttproxy:
+          software.amazon.awssdk.iotdevicesdk.GreengrassIPC:1:
+          policyDescription: "Allows access to publish to all AWS IoT Core topics. For demonstration only - use best practices in a real application"
+          operations:
+              - aws.greengrass#PublishToIoTCore
+          resources:
+              - "*"
+  Manifests:
+  - Platform:
+      os: all
+      Artifacts:
+      - URI: "<S3 Bucket URL>/software.amazon.awssdk.iotdevicesdk/1.0.0/GreengrassIPC-1.0-SNAPSHOT.jar"
+      Lifecycle:
+          RequiresPrivilege: true
+          Run: "java -cp {artifacts:path}/GreengrassIPC-1.0-SNAPSHOT.jar greengrass.GreengrassIPC "
+```
+
+Replace the following with your information:
+ * `<ComponentPublisher>` with the name you wish to publish your component under.
+ * `<S3 Bucket URL>` with the S3 bucket URL for your account to store your Greengrass components under
+
+</details>
+<br />
+
+As an example, you could use the following `gdk-config.json` below in your component with this sample and the recipe yaml shown above:
+<details>
+
+```json
+  {
+  "component": {
+      "software.amazon.awssdk.iotdevicesdk.GreengrassIPC": {
+      "author": "<ComponentPublisher>",
+      "version": "1.0.0",
+      "build": {
+          "build_system": "maven"
+      },
+      "publish": {
+          "bucket": "<S3 Bucket URL>",
+          "region": "<Region>"
+      }
+      }
+  },
+  "gdk_version": "1.0.0"
+  }
+```
+
+Replace the following with your information:
+ * `<ComponentPublisher>` with the name you wish to publish your component under.
+ * `<S3 Bucket URL>` with the S3 bucket URL for your account to store your Greengrass components under.
+ * `<Region>` the region of your S3 bucket and Greengrass device.
+
+</details>
+<br />
+
+Note that you will need to have the Java V2 SDK installed on the Greengrass device in order to compile the sample on the Greengrass device.
 
 ## MQTT5 PubSub
 


### PR DESCRIPTION
*Description of changes:*

Adds a Greengrass IPC sample to the Java V2 SDK. Tested locally to ensure it works as expected. Also adjusts README to document how to run the sample and link to references helpful for those looking to run the sample.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
