### PR TITLE
fix: exec main plugin mainClass typo

### DIFF
--- a/deviceadvisor/tests/MQTTConnect/pom.xml
+++ b/deviceadvisor/tests/MQTTConnect/pom.xml
@@ -27,7 +27,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/deviceadvisor/tests/MQTTPublish/pom.xml
+++ b/deviceadvisor/tests/MQTTPublish/pom.xml
@@ -27,7 +27,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/deviceadvisor/tests/MQTTSubscribe/pom.xml
+++ b/deviceadvisor/tests/MQTTSubscribe/pom.xml
@@ -27,7 +27,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/BasicConnect/pom.xml
+++ b/samples/BasicConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/BasicPubSub/pom.xml
+++ b/samples/BasicPubSub/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/CustomAuthorizerConnect/pom.xml
+++ b/samples/CustomAuthorizerConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/CustomKeyOpsPubSub/pom.xml
+++ b/samples/CustomKeyOpsPubSub/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/JavaKeystoreConnect/pom.xml
+++ b/samples/JavaKeystoreConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/Mqtt5/PubSub/pom.xml
+++ b/samples/Mqtt5/PubSub/pom.xml
@@ -52,7 +52,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/Pkcs11Connect/pom.xml
+++ b/samples/Pkcs11Connect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/RawConnect/pom.xml
+++ b/samples/RawConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/WebsocketConnect/pom.xml
+++ b/samples/WebsocketConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/WindowsCertConnect/pom.xml
+++ b/samples/WindowsCertConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/X509CredentialsProviderConnect/pom.xml
+++ b/samples/X509CredentialsProviderConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
*Issue #, if available:*

When importing this project in IDEA, error is given: `Element mainclass is not allowed here`.

```xml
<mainclass>main</mainclass>
```

It should be:

```xml
<mainClass>main</mainClass>
```

*Description of changes:*

Fix `exec-maven-plugin` plugin config typos.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
