### PR TITLE
fix: exec main plugin mainClass typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
     - name: MQTT5 tests
       run: |
         source utils/mqtt5_test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt us-east-1
-        mvn test -Dtest=Mqtt5BuilderTest -DfailIfNoTests=false
+        mvn test -Dtest=Mqtt5BuilderTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
         source utils/mqtt5_test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt cleanup
     - name: Running samples in CI setup
       run: |

--- a/deviceadvisor/tests/MQTTConnect/pom.xml
+++ b/deviceadvisor/tests/MQTTConnect/pom.xml
@@ -27,7 +27,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/deviceadvisor/tests/MQTTConnect/pom.xml
+++ b/deviceadvisor/tests/MQTTConnect/pom.xml
@@ -27,7 +27,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>MQTTConnect.MQTTConnect</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/deviceadvisor/tests/MQTTPublish/pom.xml
+++ b/deviceadvisor/tests/MQTTPublish/pom.xml
@@ -27,7 +27,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>MQTTPublish.MQTTPublish</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/deviceadvisor/tests/MQTTPublish/pom.xml
+++ b/deviceadvisor/tests/MQTTPublish/pom.xml
@@ -27,7 +27,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/deviceadvisor/tests/MQTTSubscribe/pom.xml
+++ b/deviceadvisor/tests/MQTTSubscribe/pom.xml
@@ -27,7 +27,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>MQTTSubscribe.MQTTSubscribe</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/deviceadvisor/tests/MQTTSubscribe/pom.xml
+++ b/deviceadvisor/tests/MQTTSubscribe/pom.xml
@@ -27,7 +27,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/BasicConnect/pom.xml
+++ b/samples/BasicConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>basicconnect.BasicConnect</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/BasicConnect/pom.xml
+++ b/samples/BasicConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/BasicPubSub/pom.xml
+++ b/samples/BasicPubSub/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/BasicPubSub/pom.xml
+++ b/samples/BasicPubSub/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>pubsub.PubSub</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/CustomAuthorizerConnect/pom.xml
+++ b/samples/CustomAuthorizerConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/CustomAuthorizerConnect/pom.xml
+++ b/samples/CustomAuthorizerConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>customauthorizerconnect.CustomAuthorizerConnect</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/CustomKeyOpsPubSub/pom.xml
+++ b/samples/CustomKeyOpsPubSub/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>customkeyopspubsub.CustomKeyOpsPubSub</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/CustomKeyOpsPubSub/pom.xml
+++ b/samples/CustomKeyOpsPubSub/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/JavaKeystoreConnect/pom.xml
+++ b/samples/JavaKeystoreConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>javakeystoreconnect.JavaKeystoreConnect</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/JavaKeystoreConnect/pom.xml
+++ b/samples/JavaKeystoreConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/Mqtt5/PubSub/pom.xml
+++ b/samples/Mqtt5/PubSub/pom.xml
@@ -52,7 +52,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>mqtt5.pubsub.PubSub</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/Mqtt5/PubSub/pom.xml
+++ b/samples/Mqtt5/PubSub/pom.xml
@@ -52,7 +52,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/Pkcs11Connect/pom.xml
+++ b/samples/Pkcs11Connect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>pkcs11connect.Pkcs11Connect</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/Pkcs11Connect/pom.xml
+++ b/samples/Pkcs11Connect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/RawConnect/pom.xml
+++ b/samples/RawConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>rawconnect.RawConnect</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/RawConnect/pom.xml
+++ b/samples/RawConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/WebsocketConnect/pom.xml
+++ b/samples/WebsocketConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>websocketconnect.WebsocketConnect</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/WebsocketConnect/pom.xml
+++ b/samples/WebsocketConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/WindowsCertConnect/pom.xml
+++ b/samples/WindowsCertConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/WindowsCertConnect/pom.xml
+++ b/samples/WindowsCertConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>windowscertconnect.WindowsCertConnect</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/X509CredentialsProviderConnect/pom.xml
+++ b/samples/X509CredentialsProviderConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainClass>main</mainClass>
+                    <mainClass>x509credentialsproviderconnect.X509CredentialsProviderConnect</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/X509CredentialsProviderConnect/pom.xml
+++ b/samples/X509CredentialsProviderConnect/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.4.0</version>
                 <configuration>
-                    <mainclass>main</mainclass>
+                    <mainClass>main</mainClass>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed the typo in exec-maven-plugin
Contribution from https://github.com/aws/aws-iot-device-sdk-java-v2/pull/373

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
