### PR TITLE
Update Fleet Provisioning sample

### DIFF
--- a/samples/Identity/src/main/java/identity/FleetProvisioningSample.java
+++ b/samples/Identity/src/main/java/identity/FleetProvisioningSample.java
@@ -50,7 +50,7 @@ public class FleetProvisioningSample {
     static CreateCertificateFromCsrResponse createCertificateFromCsrResponse = null;
     static RegisterThingResponse registerThingResponse = null;
 
-    static long responseWaitTimeMs = 2000L;
+    static long responseWaitTimeMs = 5000L; // 5 seconds
 
     static CommandLineUtils cmdUtils;
 

--- a/samples/Identity/src/main/java/identity/FleetProvisioningSample.java
+++ b/samples/Identity/src/main/java/identity/FleetProvisioningSample.java
@@ -84,6 +84,8 @@ public class FleetProvisioningSample {
             System.out.println("CreateKeysAndCertificate response certificateId: " + response.certificateId);
             if (createKeysAndCertificateResponse == null) {
                 createKeysAndCertificateResponse = response;
+            } else {
+                System.out.println("CreateKeysAndCertificate response received after having already gotten a response!");
             }
         } else {
             System.out.println("CreateKeysAndCertificate response is null");
@@ -96,6 +98,8 @@ public class FleetProvisioningSample {
             System.out.println("CreateCertificateFromCsr response certificateId: " + response.certificateId);
             if (createCertificateFromCsrResponse == null) {
                 createCertificateFromCsrResponse = response;
+            } else {
+                System.out.println("CreateCertificateFromCsr response received after having already gotten a response!");
             }
         } else {
             System.out.println("CreateCertificateFromCsr response is null");
@@ -108,6 +112,8 @@ public class FleetProvisioningSample {
             System.out.println("RegisterThing response thingName: " + response.thingName);
             if (registerThingResponse == null) {
                 registerThingResponse = response;
+            } else {
+                System.out.println("RegisterThing response received after having already gotten a response!");
             }
         } else {
             System.out.println("RegisterThing response is null");


### PR DESCRIPTION
*Description of changes:*

Adjusts the Fleet Provisioning sample so that it handles request/response like how the other Java V2 sample do, improves exiting when an error occurs (doesn't stall forever like it used to), and simplifies/reduces the sample code so it is easier to run and understand.

Will help with https://github.com/aws/aws-iot-device-sdk-java-v2/discussions/375 by improving sample error handling and response checking.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
