### PR TITLE
Shared subscription readme adjustment

### DIFF
--- a/samples/Mqtt5/SharedSubscription/README.md
+++ b/samples/Mqtt5/SharedSubscription/README.md
@@ -4,20 +4,20 @@
 
 This sample uses the
 [Message Broker](https://docs.aws.amazon.com/iot/latest/developerguide/iot-message-broker.html)
-for AWS IoT to send and receive messages through an MQTT connection using MQTT5 using a Shared Subscription.
+for AWS IoT to send and receive messages over a MQTT5 connection using a shared subscription.
 
 MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the Java V2 SDK by checking out the [MQTT5 user guide](../../../documents/MQTT5_Userguide.md).
 
 Note: MQTT5 support is currently in **developer preview**. We encourage feedback at all times, but feedback during the preview window is especially valuable in shaping the final product. During the preview period we may make backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
 
-Shared Subscriptions allow IoT devices to connect to a group where messages sent to a topic are then relayed to the group in a round-robin-like fashion. This is useful for distributing message load across multiple subscribing MQTT5 clients automatically. This is helpful for load balancing when you have many messages that need to processed.
+[Shared Subscriptions](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901250) allow IoT devices to connect to a group where messages sent to a topic are then relayed to the group in a round-robin-like fashion. This is useful for distributing message load across multiple subscribing MQTT5 clients automatically. This is helpful for load balancing when you have many messages that need to be processed.
 
-Shared Subscriptions rely on what is called a group identifier, which tells the MQTT5 broker/server which IoT devices are in what group. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
+Shared Subscriptions rely on a group identifier, which tells the MQTT5 broker/server which IoT devices to treat as a group for message distribution. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
 * `$share`: Tells the MQTT5 broker/server that the device is subscribing to a Shared Subscription.
-* `<group identifier>`: Tells the MQTT5 broker/server which group to add this Shared Subscription to. THis is the group of MQTT5 clients that will be worked through as part of the round-robin when a message comes in. For example: `my-iot-group`.
+* `<group identifier>`: Tells the MQTT5 broker/server which group to add this Shared Subscription to. Messages published to a matching topic will be distributed round-robin amongst the group.
 * `<topic>`: The topic that the Shared Subscription is for. Messages published to this topic will be processed in a round-robin fashion. For example, `test/topic`.
 
-As mentioned, Shared Subscriptions use a round-robbin like method of distributing messages. For example, say you have three MQTT5 clients all subscribed to the same Shared Subscription group and topic. If five messages are sent to the Shared Subscription topic, the messages will likely be delivered in the following order:
+Shared Subscriptions use a round-robbin like method of distributing messages. For example, say you have three MQTT5 clients all subscribed to the same Shared Subscription group and topic. If five messages are sent to the Shared Subscription topic, the messages will likely be delivered in the following order:
 * Message 1 -> Client one
 * Message 2 -> Client two
 * Message 3 -> Client three
@@ -76,8 +76,6 @@ Note that in a real application, you may want to avoid the use of wildcards in y
 </details>
 
 ## How to run
-
-### Direct MQTT via mTLS
 
 To Run this sample using a direct MQTT connection with a key and certificate, use the following command:
 

--- a/samples/Mqtt5/SharedSubscription/src/main/java/sharedsubscription/SharedSubscription.java
+++ b/samples/Mqtt5/SharedSubscription/src/main/java/sharedsubscription/SharedSubscription.java
@@ -23,11 +23,6 @@ import java.util.concurrent.TimeUnit;
 
 import utils.commandlineutils.CommandLineUtils;
 
-/**
- * MQTT5 support is currently in <b>developer preview</b>.  We encourage feedback at all times, but feedback during the
- * preview window is especially valuable in shaping the final product.  During the preview period we may make
- * backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
- */
 public class SharedSubscription {
     /**
      * When run normally, we want to exit nicely even if something goes wrong


### PR DESCRIPTION
*Description of changes:*

Makes a quick adjustment to the README of the shared subscription sample to adjust its wording. Also removes the note about MQTT5 being in developer preview from the sample source directly.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
