### PR TITLE
Add tokenKeyName and tokenValue support to MQTT311 custom auth

### DIFF
--- a/samples/CustomAuthorizerConnect/src/main/java/customauthorizerconnect/CustomAuthorizerConnect.java
+++ b/samples/CustomAuthorizerConnect/src/main/java/customauthorizerconnect/CustomAuthorizerConnect.java
@@ -77,7 +77,9 @@ public class CustomAuthorizerConnect {
                 cmdData.input_customAuthUsername,
                 cmdData.input_customAuthorizerName,
                 cmdData.input_customAuthorizerSignature,
-                cmdData.input_customAuthPassword);
+                cmdData.input_customAuthPassword,
+                cmdData.input_customAuthorizerTokenKeyName,
+                cmdData.input_customAuthorizerTokenValue);
             MqttClientConnection connection = builder.build();
             builder.close();
 

--- a/samples/Utils/CommandLineUtils/utils/commandlineutils/CommandLineUtils.java
+++ b/samples/Utils/CommandLineUtils/utils/commandlineutils/CommandLineUtils.java
@@ -205,6 +205,8 @@ public class CommandLineUtils {
         public String input_customAuthorizerName;
         public String input_customAuthorizerSignature;
         public String input_customAuthPassword;
+        public String input_customAuthorizerTokenKeyName;
+        public String input_customAuthorizerTokenValue;
         // Fleet provisioning
         public String input_templateName;
         public String input_templateParameters;
@@ -326,6 +328,8 @@ public class CommandLineUtils {
         registerCommand(m_cmd_custom_auth_authorizer_name, "<str>", "Name of custom authorizer (optional, default=null).");
         registerCommand(m_cmd_custom_auth_authorizer_signature, "<str>", "Signature passed when connecting to custom authorizer (optional, default=null).");
         registerCommand(m_cmd_custom_auth_password, "<str>", "Password for connecting to custom authorizer (optional, default=null).");
+        registerCommand(m_cmd_custom_auth_token_key_name, "<str>", "Key used to extract the custom authorizer token (optional, default=null).");
+        registerCommand(m_cmd_custom_auth_token_value, "<str>", "The opaque token value for the custom authorizer (optional, default=null).");
         sendArguments(args);
 
         SampleCommandLineData returnData = new SampleCommandLineData();
@@ -335,6 +339,8 @@ public class CommandLineUtils {
         returnData.input_customAuthorizerName = getCommandOrDefault(m_cmd_custom_auth_authorizer_name, null);
         returnData.input_customAuthorizerSignature = getCommandOrDefault(m_cmd_custom_auth_authorizer_signature, null);
         returnData.input_customAuthPassword = getCommandOrDefault(m_cmd_custom_auth_password, null);
+        returnData.input_customAuthorizerTokenKeyName = getCommandOrDefault(m_cmd_custom_auth_token_key_name, null);
+        returnData.input_customAuthorizerTokenValue = getCommandOrDefault(m_cmd_custom_auth_token_value, null);
         return returnData;
     }
 
@@ -706,6 +712,8 @@ public class CommandLineUtils {
     private static final String m_cmd_custom_auth_authorizer_name = "custom_auth_authorizer_name";
     private static final String m_cmd_custom_auth_authorizer_signature = "custom_auth_authorizer_signature";
     private static final String m_cmd_custom_auth_password = "custom_auth_password";
+    private static final String m_cmd_custom_auth_token_key_name = "custom_auth_token_key_name";
+    private static final String m_cmd_custom_auth_token_value = "custom_auth_token_value";
     private static final String m_cmd_javakeystore_path = "keystore";
     private static final String m_cmd_javakeystore_password = "keystore_password";
     private static final String m_cmd_javakeystore_format = "keystore_format";

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -121,6 +121,7 @@
                 <source>greengrass/greengrass-client/src/test/java</source>
                 <!-- IOT tests -->
                 <source>tests/iot</source>
+                <source>tests/mqtt</source>
                 <!-- MQTT5 tests -->
                 <source>tests/mqtt5</source>
               </sources>

--- a/sdk/tests/mqtt/MqttBuilderTest.java
+++ b/sdk/tests/mqtt/MqttBuilderTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
+import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
+
+/**
+ * NOTE: Will later add more testing and split MQTT5 testing setup from MQTT311 testing setup.
+ * In the short term, the MQTT311 tests will reuse the majority of MQTT5 material.
+ */
+
+public class MqttBuilderTest {
+
+    private String mqtt5IoTCoreHost;
+
+    private String mqtt5IoTCoreNoSigningAuthorizerName;
+    private String mqtt5IoTCoreNoSigningAuthorizerUsername;
+    private String mqtt5IoTCoreNoSigningAuthorizerPassword;
+
+    private String mqtt5IoTCoreSigningAuthorizerName;
+    private String mqtt5IoTCoreSigningAuthorizerUsername;
+    private String mqtt5IoTCoreSigningAuthorizerPassword;
+    private String mqtt5IoTCoreSigningAuthorizerToken;
+    private String mqtt5IoTCoreSigningAuthorizerTokenKeyName;
+    private String mqtt5IoTCoreSigningAuthorizerTokenSignature;
+
+    private void populateTestingEnvironmentVariables() {
+        mqtt5IoTCoreHost = System.getenv("AWS_TEST_MQTT5_IOT_CORE_HOST");
+
+        mqtt5IoTCoreNoSigningAuthorizerName = System.getenv("AWS_TEST_MQTT5_IOT_CORE_NO_SIGNING_AUTHORIZER_NAME");
+        mqtt5IoTCoreNoSigningAuthorizerUsername = System.getenv("AWS_TEST_MQTT5_IOT_CORE_NO_SIGNING_AUTHORIZER_USERNAME");
+        mqtt5IoTCoreNoSigningAuthorizerPassword = System.getenv("AWS_TEST_MQTT5_IOT_CORE_NO_SIGNING_AUTHORIZER_PASSWORD");
+
+        mqtt5IoTCoreSigningAuthorizerName = System.getenv("AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_NAME");
+        mqtt5IoTCoreSigningAuthorizerUsername = System.getenv("AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_USERNAME");
+        mqtt5IoTCoreSigningAuthorizerPassword = System.getenv("AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_PASSWORD");
+        mqtt5IoTCoreSigningAuthorizerToken = System.getenv("AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_TOKEN");
+        mqtt5IoTCoreSigningAuthorizerTokenKeyName = System.getenv("AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_TOKEN_KEY_NAME");
+        mqtt5IoTCoreSigningAuthorizerTokenSignature = System.getenv("AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_TOKEN_SIGNATURE");
+    }
+
+    MqttBuilderTest() {
+        populateTestingEnvironmentVariables();
+    }
+
+    /**
+     * ============================================================
+     * IOT BUILDER TEST CASES
+     * ============================================================
+     */
+
+    /* MQTT311 Custom Auth (no signing) connect */
+    @Test
+    public void ConnIoT_CustomAuth_UC1()
+    {
+        assumeTrue(mqtt5IoTCoreHost != null);
+        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerName != null);
+        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerUsername != null);
+        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerPassword != null);
+
+        try {
+            AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
+            builder.withEndpoint(mqtt5IoTCoreHost);
+            builder.withCustomAuthorizer(
+                mqtt5IoTCoreNoSigningAuthorizerUsername,
+                mqtt5IoTCoreSigningAuthorizerName,
+                null,
+                mqtt5IoTCoreNoSigningAuthorizerPassword,
+                null,
+                null);
+            MqttClientConnection connection = builder.build();
+            builder.close();
+
+            connection.connect().get();
+            connection.disconnect().get();
+            connection.close();
+
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
+
+    /* MQTT311 Custom Auth (with signing) connect */
+    @Test
+    public void ConnIoT_CustomAuth_UC2()
+    {
+        assumeTrue(mqtt5IoTCoreHost != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerUsername != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerPassword != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerToken != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenKeyName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
+
+        try {
+            AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
+            builder.withEndpoint(mqtt5IoTCoreHost);
+            builder.withCustomAuthorizer(
+                mqtt5IoTCoreSigningAuthorizerUsername,
+                mqtt5IoTCoreSigningAuthorizerName,
+                mqtt5IoTCoreSigningAuthorizerTokenSignature,
+                mqtt5IoTCoreSigningAuthorizerPassword,
+                mqtt5IoTCoreSigningAuthorizerTokenKeyName,
+                mqtt5IoTCoreSigningAuthorizerToken);
+            MqttClientConnection connection = builder.build();
+            builder.close();
+
+            connection.connect().get();
+            connection.disconnect().get();
+            connection.close();
+
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
+
+}


### PR DESCRIPTION
*Description of changes:*

The current MQTT311 custom auth implementation is missing the ability to set the custom authorizer token key name and token key value, making it impossible to login with a signed custom authorizer using the builder.

This PR adds the support for the custom auth token key name and token key value. The change is completely backwards compatible as the new values are optional via a new function definition.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
