### PR TITLE
Add missing `cd` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ mkdir sdk-workspace
 cd sdk-workspace
 # Clone the repository
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git
+cd aws-iot-device-sdk-java-v2
 # Compile and install
 mvn clean install
 ```


### PR DESCRIPTION
* Add missing `cd` step in install instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
