### PR TITLE
Full backwards compat with custom auth in MQTT311

### DIFF
--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
@@ -642,13 +642,15 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
         if (authorizerSignature != null)
         {
             usernameString = addUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=", addedStringToUsername);
-            Log.log(
-                LogLevel.Warn,
-                LogSubject.MqttClient,
-                "Signed custom authorizers with signature will not work without a token key name and " +
-                "token value. Your connection may be rejected/stalled on the IoT Core side due to this. Please " +
-                "use the non-deprecate API and pass both the token key name and token value to connect to a " +
-                "signed custom authorizer");
+            if (tokenKeyName == null || tokenValue == null) {
+                Log.log(
+                    LogLevel.Warn,
+                    LogSubject.MqttClient,
+                    "Signed custom authorizers with signature will not work without a token key name and " +
+                    "token value. Your connection may be rejected/stalled on the IoT Core side due to this. Please " +
+                    "use the non-deprecate API and pass both the token key name and token value to connect to a " +
+                    "signed custom authorizer");
+            }
         }
         if (authorizerSignature != null || tokenKeyName != null || tokenValue != null) {
             if (tokenKeyName == null || tokenValue == null) {

--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
@@ -588,7 +588,7 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
      *                       will not be added with the MQTT connection.
      * @param authorizerSignature The signature of the custom authorizer.
      *                            NOTE: This will NOT work without the token key name and token value, which requires
-     *                            using the non-depreciated API. This will always fail if set.
+     *                            using the non-depreciated API.
      * @param password The password to use with the custom authorizer. If null is passed, then no password will be set.
      * @return {@link AwsIotMqttConnectionBuilder}
      */
@@ -639,11 +639,21 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
             usernameString = addUsernameParameter(usernameString, authorizerName, "x-amz-customauthorizer-name=", addedStringToUsername);
             addedStringToUsername = true;
         }
+        if (authorizerSignature != null)
+        {
+            usernameString = addUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=", addedStringToUsername);
+            Log.log(
+                LogLevel.Warn,
+                LogSubject.MqttClient,
+                "Signed custom authorizers with signature will not work without a token key name and " +
+                "token value. Your connection may be rejected/stalled on the IoT Core side due to this. Please " +
+                "use the non-deprecate API and pass both the token key name and token value to connect to a " +
+                "signed custom authorizer");
+        }
         if (authorizerSignature != null || tokenKeyName != null || tokenValue != null) {
-            if (authorizerSignature == null || tokenKeyName == null || tokenValue == null) {
+            if (tokenKeyName == null || tokenValue == null) {
                 throw new RuntimeException("Token-based custom authentication requires all token-related properties to be set");
             }
-            usernameString = addUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=", addedStringToUsername);
             usernameString = addUsernameParameter(usernameString, tokenValue, tokenKeyName + "=", addedStringToUsername);
         }
 

--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
@@ -586,8 +586,9 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
      *                 no username will be passed with the MQTT connection.
      * @param authorizerName The name of the custom authorizer. If null is passed, then 'x-amz-customauthorizer-name'
      *                       will not be added with the MQTT connection.
-     * @param authorizerSignature The signature of the custom authorizer. If null is passed, then 'x-amz-customauthorizer-signature'
-     *                  will not be added with the MQTT connection.
+     * @param authorizerSignature The signature of the custom authorizer.
+     *                            NOTE: This will NOT work without the token key name and token value, which requires
+     *                            using the non-depreciated API. This will always fail if set.
      * @param password The password to use with the custom authorizer. If null is passed, then no password will be set.
      * @return {@link AwsIotMqttConnectionBuilder}
      */
@@ -638,14 +639,11 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
             usernameString = addUsernameParameter(usernameString, authorizerName, "x-amz-customauthorizer-name=", addedStringToUsername);
             addedStringToUsername = true;
         }
-        if (authorizerSignature != null)
-        {
-            usernameString = addUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=", addedStringToUsername);
-        }
-        if (tokenKeyName != null || tokenValue != null) {
-            if (tokenKeyName == null || tokenValue == null) {
+        if (authorizerSignature != null || tokenKeyName != null || tokenValue != null) {
+            if (authorizerSignature == null || tokenKeyName == null || tokenValue == null) {
                 throw new RuntimeException("Token-based custom authentication requires all token-related properties to be set");
             }
+            usernameString = addUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=", addedStringToUsername);
             usernameString = addUsernameParameter(usernameString, tokenValue, tokenKeyName + "=", addedStringToUsername);
         }
 

--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
@@ -638,11 +638,14 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
             usernameString = addUsernameParameter(usernameString, authorizerName, "x-amz-customauthorizer-name=", addedStringToUsername);
             addedStringToUsername = true;
         }
-        if (authorizerSignature != null || tokenKeyName != null || tokenValue != null) {
-            if (authorizerSignature == null || tokenKeyName == null || tokenValue == null) {
+        if (authorizerSignature != null)
+        {
+            usernameString = addUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=", addedStringToUsername);
+        }
+        if (tokenKeyName != null || tokenValue != null) {
+            if (tokenKeyName == null || tokenValue == null) {
                 throw new RuntimeException("Token-based custom authentication requires all token-related properties to be set");
             }
-            usernameString = addUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=", addedStringToUsername);
             usernameString = addUsernameParameter(usernameString, tokenValue, tokenKeyName + "=", addedStringToUsername);
         }
 


### PR DESCRIPTION
*Description of changes:*

~~Minor adjustment to stay 100% fully backwards compatible with the MQTT311 custom authorizer API, even if it technically won't/shouldn't work with the old API.~~

Adjusts documentation to note that passing a custom authorizer signature with the old API will always fail.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
