### PR TITLE
Run Greengrass Basic Discovery in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ env:
   CI_SHADOW_ROLE: arn:aws:iam::180635532705:role/CI_Shadow_Role
   CI_JOBS_ROLE: arn:aws:iam::180635532705:role/CI_Jobs_Role
   CI_FLEET_PROVISIONING_ROLE: arn:aws:iam::180635532705:role/service-role/CI_FleetProvisioning_Role
+  CI_GREENGRASS_ROLE: arn:aws:iam::180635532705:role/CI_Greengrass_Role
   CI_DEVICE_ADVISOR: arn:aws:iam::180635532705:role/CI_DeviceAdvisor_Role
   CI_X509_ROLE: arn:aws:iam::180635532705:role/CI_X509_Role
   CI_MQTT5_ROLE: arn:aws:iam::180635532705:role/CI_MQTT5_Role
@@ -443,3 +444,11 @@ jobs:
       - name: run MQTT5 Shared Subscription sample
         run: |
           python3 ./utils/run_sample_ci.py --file ./.github/workflows/ci_run_mqtt5_shared_subscription_cfg.json
+      - name: configure AWS credentials (Greengrass)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.CI_GREENGRASS_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: run Greengrass Discovery sample
+        run: |
+          python3 ./utils/run_sample_ci.py --file ./.github/workflows/ci_run_greengrass_discovery_cfg.json

--- a/.github/workflows/ci_run_greengrass_discovery_cfg.json
+++ b/.github/workflows/ci_run_greengrass_discovery_cfg.json
@@ -1,0 +1,35 @@
+{
+    "language": "Java",
+    "sample_file": "samples/Greengrass",
+    "sample_region": "us-east-1",
+    "sample_main_class": "greengrass.BasicDiscovery",
+    "arguments": [
+        {
+            "name": "--cert",
+            "secret": "ci/Greengrass/cert",
+            "filename": "tmp_certificate.pem"
+        },
+        {
+            "name": "--key",
+            "secret": "ci/Greengrass/key",
+            "filename": "tmp_key.pem"
+        },
+        {
+            "name": "--ca_file",
+            "secret": "ci/Greengrass/ca",
+            "filename": "tmp_ca.pem"
+        },
+        {
+            "name": "--region",
+            "data": "us-east-1"
+        },
+        {
+            "name": "--thing_name",
+            "data": "CI_GreenGrass_Thing"
+        },
+        {
+            "name": "--print_discover_resp_only",
+            "data": ""
+        }
+    ]
+}

--- a/samples/Utils/CommandLineUtils/utils/commandlineutils/CommandLineUtils.java
+++ b/samples/Utils/CommandLineUtils/utils/commandlineutils/CommandLineUtils.java
@@ -247,6 +247,8 @@ public class CommandLineUtils {
         // PKCS12
         public String input_pkcs12File;
         public String input_pkcs12Password;
+        // Greengrass Basic Discovery
+        public Boolean inputPrintDiscoverRespOnly;
     }
 
     // Helper function for getting the message and topic
@@ -399,6 +401,7 @@ public class CommandLineUtils {
         registerCommand(m_cmd_thing_name, "<str>", "The name of the IoT thing.");
         registerCommand(m_cmd_topic, "<str>", "Topic to subscribe/publish to (optional, default='test/topic').");
         registerCommand(m_cmd_mode, "<str>", "Mode options: 'both', 'publish', or 'subscribe' (optional, default='both').");
+        registerCommand(m_cmd_print_discover_resp_only, "<str>", "Exists the sample after printing the discovery result (optional, default='False')");
         addCommonProxyCommands();
         sendArguments(args);
 
@@ -412,6 +415,7 @@ public class CommandLineUtils {
         returnData.input_proxyPort = Integer.parseInt(getCommandOrDefault(m_cmd_proxy_port, "0"));
         returnData.input_topic = getCommandOrDefault(m_cmd_topic, "test/topic");
         returnData.input_mode = getCommandOrDefault(m_cmd_mode, "Hello World!");
+        returnData.inputPrintDiscoverRespOnly = hasCommand(m_cmd_print_discover_resp_only);
         return returnData;
     }
 
@@ -738,6 +742,7 @@ public class CommandLineUtils {
     private static final String m_cmd_pkcs12_file = "pkcs12_file";
     private static final String m_cmd_pkcs12_password = "pkcs12_password";
     private static final String m_cmd_region = "region";
+    private static final String m_cmd_print_discover_resp_only = "print_discover_resp_only";
 }
 
 class CommandLineOption {

--- a/utils/run_sample_ci.py
+++ b/utils/run_sample_ci.py
@@ -83,7 +83,8 @@ def setup_json_arguments_list(parsed_commands):
                 if isinstance(tmp_value, str) and 'input_uuid' in parsed_commands:
                     if ("$INPUT_UUID" in tmp_value):
                         tmp_value = tmp_value.replace("$INPUT_UUID", parsed_commands.input_uuid)
-                config_json_arguments_list.append(tmp_value)
+                if (tmp_value != None and tmp_value != ""):
+                    config_json_arguments_list.append(tmp_value)
 
             # None of the above? Just print an error
             else:


### PR DESCRIPTION
*Description of changes:*

Adds running the Greengrass discovery sample in CI. It also unifies the command line options with the Python SDK, which allows for only printing the discovery information. Now the sample has been adjusted to print the discovery information and, if the option is set, it will only print the discovery information. Previously the sample didn't print the discovery information at all. I tried to make the print format similar to Python.

This PR also changes the sample a bit so it doesn't require passing a CA file (though it still works if you pass one) and removes checks to make sure the input files are present, as none of the other samples do this and on the CRT layer we print if the files are missing - making it redundant.

_____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
