### PR TITLE
Adjust the Greengrass Discovery client to use its own executor service

### DIFF
--- a/sdk/src/main/java/software/amazon/awssdk/iot/discovery/DiscoveryClient.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/discovery/DiscoveryClient.java
@@ -12,9 +12,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
  * Class for performing network-based discovery of the connectivity properties of registered greengrass cores
@@ -38,18 +35,10 @@ public class DiscoveryClient implements AutoCloseable {
     private final HttpClientConnectionManager httpClientConnectionManager;
 
     /**
-     * We need to use a custom executor to avoid leaving threads alive when the discovery client is closed
-     * It also fixes issues with the SecurityManager as well - as created ExecutorServices created via code
-     * inherit the permissions of the application, unlike the default common thread pool.
-     */
-    private final ExecutorService executorService;
-
-    /**
      *
      * @param config Greengrass discovery client configuration
      */
     public DiscoveryClient(final DiscoveryClientConfig config) {
-        this.executorService = Executors.newFixedThreadPool(1);
         this.httpClientConnectionManager = HttpClientConnectionManager.create(
                 new HttpClientConnectionManagerOptions()
                     .withClientBootstrap(config.getBootstrap())
@@ -70,49 +59,57 @@ public class DiscoveryClient implements AutoCloseable {
         if(thingName == null) {
             throw new IllegalArgumentException("ThingName cannot be null!");
         }
-        return CompletableFuture.supplyAsync(() -> {
-            try(final HttpClientConnection connection = httpClientConnectionManager.acquireConnection().get()) {
-                final String requestHttpPath =  "/greengrass/discover/thing/" + thingName;
-                final HttpHeader[] headers = new HttpHeader[] {
-                        new HttpHeader("host", httpClientConnectionManager.getUri().getHost())
-                };
-                final HttpRequest request = new HttpRequest("GET", requestHttpPath, headers, null);
-                //we are storing everything until we get the entire response
-                final CompletableFuture<Integer> responseComplete = new CompletableFuture<>();
-                final StringBuilder jsonBodyResponseBuilder = new StringBuilder();
-                final Map<String, String> responseInfo = new HashMap<>();
-                try(final HttpStream stream = connection.makeRequest(request, new HttpStreamResponseHandler() {
-                        @Override
-                        public void onResponseHeaders(HttpStream stream, int responseStatusCode, int blockType, HttpHeader[] httpHeaders) {
-                            Arrays.stream(httpHeaders).forEach(header -> {
-                                responseInfo.put(header.getName(), header.getValue());
-                            });
+
+        CompletableFuture<DiscoverResponse> result = new CompletableFuture<>();
+        // We create and start a thread so it executes asynchronously and independently from the main process. The thread will set the
+        // result CompletableFuture when it is done or if an exception occurs.
+        new Thread(() -> {
+            try {
+                try (final HttpClientConnection connection = httpClientConnectionManager.acquireConnection().get()) {
+                    final String requestHttpPath =  "/greengrass/discover/thing/" + thingName;
+                    final HttpHeader[] headers = new HttpHeader[] {
+                            new HttpHeader("host", httpClientConnectionManager.getUri().getHost())
+                    };
+                    final HttpRequest request = new HttpRequest("GET", requestHttpPath, headers, null);
+                    //we are storing everything until we get the entire response
+                    final CompletableFuture<Integer> responseComplete = new CompletableFuture<>();
+                    final StringBuilder jsonBodyResponseBuilder = new StringBuilder();
+                    final Map<String, String> responseInfo = new HashMap<>();
+
+                    try (final HttpStream stream = connection.makeRequest(request, new HttpStreamResponseHandler() {
+                            @Override
+                            public void onResponseHeaders(HttpStream stream, int responseStatusCode, int blockType, HttpHeader[] httpHeaders) {
+                                Arrays.stream(httpHeaders).forEach(header -> {
+                                    responseInfo.put(header.getName(), header.getValue());
+                                });
+                            }
+                            @Override
+                            public int onResponseBody(HttpStream stream, byte bodyBytes[]) {
+                                jsonBodyResponseBuilder.append(new String(bodyBytes, StandardCharsets.UTF_8));
+                                return bodyBytes.length;
+                            }
+                            @Override
+                            public void onResponseComplete(HttpStream httpStream, int errorCode) {
+                                responseComplete.complete(errorCode);
+                            }
+                         }))
+                         {
+                            stream.activate();
+                            responseComplete.get();
+                            if (stream.getResponseStatusCode() != 200) {
+                                throw new RuntimeException(String.format("Error %s(%d); RequestId: %s",
+                                        HTTP_HEADER_ERROR_TYPE, stream.getResponseStatusCode(), HTTP_HEADER_REQUEST_ID));
+                            }
+                            final String responseString = jsonBodyResponseBuilder.toString();
+                            result.complete(GSON.fromJson(new StringReader(responseString), DiscoverResponse.class));
                         }
-                        @Override
-                        public int onResponseBody(HttpStream stream, byte bodyBytes[]) {
-                            jsonBodyResponseBuilder.append(new String(bodyBytes, StandardCharsets.UTF_8));
-                            return bodyBytes.length;
-                        }
-                        @Override
-                        public void onResponseComplete(HttpStream httpStream, int errorCode) {
-                            responseComplete.complete(errorCode);
-                        }})) {
-                    stream.activate();
-                    responseComplete.get();
-                    if (stream.getResponseStatusCode() != 200) {
-                        throw new RuntimeException(String.format("Error %s(%d); RequestId: %s",
-                                HTTP_HEADER_ERROR_TYPE, stream.getResponseStatusCode(), HTTP_HEADER_REQUEST_ID));
-                    }
-                    final String responseString = jsonBodyResponseBuilder.toString();
-                    return GSON.fromJson(new StringReader(responseString), DiscoverResponse.class);
-                } catch (InterruptedException | ExecutionException e) {
-                    throw new RuntimeException(e);
                 }
+            } catch(Exception ex) {
+                result.completeExceptionally(ex);
             }
-            catch(InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e.getMessage(), e);
-            }
-        }, executorService);
+        }).start();
+
+        return result;
     }
 
     private static String getHostname(final DiscoveryClientConfig config) {
@@ -129,9 +126,6 @@ public class DiscoveryClient implements AutoCloseable {
     public void close() {
         if(httpClientConnectionManager != null) {
             httpClientConnectionManager.close();
-        }
-        if (executorService != null) {
-            executorService.shutdown();
         }
     }
 }

--- a/sdk/src/main/java/software/amazon/awssdk/iot/discovery/DiscoveryClientConfig.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/discovery/DiscoveryClientConfig.java
@@ -1,5 +1,7 @@
 package software.amazon.awssdk.iot.discovery;
 
+import java.util.concurrent.ExecutorService;
+
 import software.amazon.awssdk.crt.http.HttpProxyOptions;
 import software.amazon.awssdk.crt.io.ClientBootstrap;
 import software.amazon.awssdk.crt.io.SocketOptions;
@@ -17,6 +19,7 @@ public class DiscoveryClientConfig implements AutoCloseable {
     final private int maxConnections;
     final private HttpProxyOptions proxyOptions;
     final private String ggServerName;
+    private ExecutorService discoveryExecutor;
 
     /**
      * Constructor for DiscoveryClientConfig creates the correct endpoint if not in a special region
@@ -44,6 +47,7 @@ public class DiscoveryClientConfig implements AutoCloseable {
         this.maxConnections = maxConnections;
         this.proxyOptions = proxyOptions;
         this.ggServerName = "";
+        this.discoveryExecutor = null;
     }
 
     /**
@@ -70,7 +74,7 @@ public class DiscoveryClientConfig implements AutoCloseable {
 
     /**
      * Default Constructor for DiscoveryClientConfig that allows the specification of a specific ggServerName to use in special regions
-     * 
+     *
      * @param bootstrap client bootstrap to use to establish network connections
      * @param tlsContextOptions tls configuration for client network connections.  For greengrass discovery, the
      *                          tls context must be initialized with the certificate and private key of the
@@ -94,6 +98,7 @@ public class DiscoveryClientConfig implements AutoCloseable {
         this.maxConnections = maxConnections;
         this.proxyOptions = proxyOptions;
         this.ggServerName = ggServerName;
+        this.discoveryExecutor = null;
     }
 
     /**
@@ -162,6 +167,27 @@ public class DiscoveryClientConfig implements AutoCloseable {
 
     public String getGGServerName() {
         return ggServerName;
+    }
+
+    /**
+     * @return the executor set for this discover client, if one is set.
+     */
+    public ExecutorService getDiscoveryExecutor() {
+        return this.discoveryExecutor;
+    }
+
+    /**
+     * Sets the executor that is used when calling discover().
+     * If set using this function, you are expected to close/shutdown the executor when finished with it.
+     *
+     * If it is not set, the discovery client will internally manage its own executor.
+     *
+     * @param override The executor to use
+     * @return The client config
+     */
+    public DiscoveryClientConfig setDiscoveryExecutor(ExecutorService override) {
+        this.discoveryExecutor = override;
+        return this;
     }
 
     @Override

--- a/sdk/src/main/java/software/amazon/awssdk/iot/discovery/DiscoveryClientConfig.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/discovery/DiscoveryClientConfig.java
@@ -170,7 +170,7 @@ public class DiscoveryClientConfig implements AutoCloseable {
     }
 
     /**
-     * @return the executor set for this discover client, if one is set.
+     * @return the ExecutorService set for this discover client config. Returns null if one hasn't been set.
      */
     public ExecutorService getDiscoveryExecutor() {
         return this.discoveryExecutor;


### PR DESCRIPTION
*Issue #, if available:*

Fixes #320

*Description of changes:*

As part of #426, I was investigating why I was getting warnings saying threads were not being closed and it was resulting in a roughly minute long delay at the end of the sample, though the sample itself works fine and all the code executes. 

The warning I got with the sample running locally in #426 was:

~~~
[WARNING] thread Thread[#33,ForkJoinPool.commonPool-worker-1,5,greengrass.BasicDiscovery] was interrupted but is still alive after waiting at least 15000msecs
[WARNING] thread Thread[#33,ForkJoinPool.commonPool-worker-1,5,greengrass.BasicDiscovery] will linger despite being asked to die via interruption
[WARNING] thread Thread[#34,ForkJoinPool.commonPool-worker-2,5,greengrass.BasicDiscovery] will linger despite being asked to die via interruption
[WARNING] NOTE: 2 thread(s) did not finish despite being asked to  via interruption. This is not a problem with exec:java, it is a problem with the running code. Although not serious, it should be remedied.
~~~

Which was a bit concerning as it seemed some thread was lingering after the sample was finished.

After a bunch of researching, poking around the code, and looking around, I concluded the issue seemed to be due to the common thread pool being used and not being properly cleaned up by default because it uses daemon/non-daemon threads and using the wrong type can lead the JVM to finish before the thread, orphaning the thread (if my admitted limited understanding is correct).
By default, `supplyAsync()` uses the default common thread pool, which has a tendency to have this issue to occur, apparently from what I gathered. While I didn't find an exact case that was showing the warnings I was seeing or was like our code with `supplyAsync`, the overall common advice I found while researching is to make and manage a thread pool, calling `shutdown` when finished, which frees the threads in question.

I made the adjustment in this PR, making the code manage its own single thread pool just for this single purpose. It also adds a new configuration option to set the executor manually, if desired, in the discovery client config. If set manually, the customer is expected to shut the executor down when finished. (this is also documented)

I tested and with this change, the minute long delay and warnings were gone! Everything still functions properly too.

Looking at the issue in #320, it seemed similar and so I tested it, and it seems to work there now too! I confirmed that without the change the issue occurs and you get an exception, and with the change, the issue is not present. Based on really quick research into that issue, it seems that the default common thread pool does NOT carry over the permissions of the executing Jar, but if you make one manually, it does properly inherit the security permissions.

**TLDR**: The delay that I was seeing in #426 is fixed by having the discovery client make and destroy its own thread pool in an executor service, and it happened to fix the SecurityManager issue as well.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
