### PR TITLE
handle SocketOptions not being set

### DIFF
--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqttConnectionBuilder.java
@@ -360,6 +360,9 @@ public final class AwsIotMqttConnectionBuilder extends CrtResource {
      * @return {@link AwsIotMqttConnectionBuilder}
      */
     public AwsIotMqttConnectionBuilder withTimeoutMs(int timeoutMs) {
+        if (this.config.getSocketOptions() == null) {
+            this.withSocketOptions(new SocketOptions());
+        }
         this.config.getSocketOptions().connectTimeoutMs = timeoutMs;
         return this;
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-crt-java/issues/650

*Description of changes:*
create new `SocketOptions` if it doesn't exist to avoid null pointer exception


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
