### PR TITLE
Doc: Fix build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ cd aws-crt-java
 mvn install -Dmaven.test.skip=true
 # Clone the SDK repository
 git clone https://github.com/awslabs/aws-iot-device-sdk-java-v2.git
-cd ../aws-iot-device-sdk-java-v2
+cd aws-iot-device-sdk-java-v2
 # Compile and install
 mvn clean install
 ```


### PR DESCRIPTION

Fix Doc instruction, when a ".." will cause a path not found

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
