### PR TITLE
Fix custom auth tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,12 @@ jobs:
       with:
         role-to-assume: ${{ env.CI_MQTT5_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: MQTT311 tests
+      shell: bash
+      run: |
+        source utils/mqtt5_test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt us-east-1
+        mvn test -Dtest=MqttBuilderTest -Dsurefire.failIfNoSpecifiedTests=false
+        source utils/mqtt5_test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt cleanup
     - name: MQTT5 tests
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,11 @@ jobs:
       with:
         role-to-assume: ${{ env.CI_MQTT5_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: MQTT311 tests
+      run: |
+        source utils/mqtt5_test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt us-east-1
+        mvn test -Dtest=MqttBuilderTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
+        source utils/mqtt5_test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt cleanup
     - name: MQTT5 tests
       run: |
         source utils/mqtt5_test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt us-east-1
@@ -308,6 +313,11 @@ jobs:
         with:
           role-to-assume: ${{ env.CI_MQTT5_ROLE }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: MQTT311 tests
+        run: |
+          source utils/mqtt5_test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt us-east-1
+          mvn test -Dtest=MqttBuilderTest -DfailIfNoTests=false
+          source utils/mqtt5_test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt cleanup
       - name: MQTT5 tests
         run: |
           source utils/mqtt5_test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt us-east-1

--- a/sdk/tests/mqtt/MqttBuilderTest.java
+++ b/sdk/tests/mqtt/MqttBuilderTest.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 public class MqttBuilderTest {
 
     private String mqtt5IoTCoreHost;
+    private String mqtt5IoTCoreRegion;
 
     private String mqtt5IoTCoreNoSigningAuthorizerName;
     private String mqtt5IoTCoreNoSigningAuthorizerUsername;
@@ -34,6 +35,7 @@ public class MqttBuilderTest {
 
     private void populateTestingEnvironmentVariables() {
         mqtt5IoTCoreHost = System.getenv("AWS_TEST_MQTT5_IOT_CORE_HOST");
+        mqtt5IoTCoreRegion = System.getenv("AWS_TEST_MQTT5_IOT_CORE_REGION");
 
         mqtt5IoTCoreNoSigningAuthorizerName = System.getenv("AWS_TEST_MQTT5_IOT_CORE_NO_SIGNING_AUTHORIZER_NAME");
         mqtt5IoTCoreNoSigningAuthorizerUsername = System.getenv("AWS_TEST_MQTT5_IOT_CORE_NO_SIGNING_AUTHORIZER_USERNAME");
@@ -127,73 +129,77 @@ public class MqttBuilderTest {
     }
 
         /* Custom Auth (no signing) connect - Websockets */
-    // @Test
-    // public void ConnIoT_CustomAuth_UC3()
-    // {
-    //     assumeTrue(mqtt5IoTCoreHost != null);
-    //     assumeTrue(mqtt5IoTCoreNoSigningAuthorizerName != null);
-    //     assumeTrue(mqtt5IoTCoreNoSigningAuthorizerUsername != null);
-    //     assumeTrue(mqtt5IoTCoreNoSigningAuthorizerPassword != null);
+    @Test
+    public void ConnIoT_CustomAuth_UC3()
+    {
+        assumeTrue(mqtt5IoTCoreHost != null);
+        assumeTrue(mqtt5IoTCoreRegion != null);
+        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerName != null);
+        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerUsername != null);
+        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerPassword != null);
 
-    //     try {
-    //         AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
-    //         builder.withEndpoint(mqtt5IoTCoreHost);
-    //         String clientId = "test-" + UUID.randomUUID().toString();
-    //         builder.withClientId(clientId);
-    //         builder.withCustomAuthorizer(
-    //             mqtt5IoTCoreNoSigningAuthorizerUsername,
-    //             mqtt5IoTCoreNoSigningAuthorizerName,
-    //             null,
-    //             mqtt5IoTCoreNoSigningAuthorizerPassword,
-    //             null,
-    //             null);
-    //         builder.withWebsockets(true);
-    //         MqttClientConnection connection = builder.build();
-    //         builder.close();
+        try {
+            AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
+            builder.withEndpoint(mqtt5IoTCoreHost);
+            String clientId = "test-" + UUID.randomUUID().toString();
+            builder.withClientId(clientId);
+            builder.withCustomAuthorizer(
+                mqtt5IoTCoreNoSigningAuthorizerUsername,
+                mqtt5IoTCoreNoSigningAuthorizerName,
+                null,
+                mqtt5IoTCoreNoSigningAuthorizerPassword,
+                null,
+                null);
+            builder.withWebsockets(true);
+            builder.withWebsocketSigningRegion(mqtt5IoTCoreRegion);
+            MqttClientConnection connection = builder.build();
+            builder.close();
 
-    //         connection.connect().get();
-    //         connection.disconnect().get();
-    //         connection.close();
+            connection.connect().get();
+            connection.disconnect().get();
+            connection.close();
 
-    //     } catch (Exception ex) {
-    //         fail(ex);
-    //     }
-    // }
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
 
-    // /* Custom Auth (with signing) connect - Websockets */
-    // @Test
-    // public void ConnIoT_CustomAuth_UC4()
-    // {
-    //     assumeTrue(mqtt5IoTCoreHost != null);
-    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerName != null);
-    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerUsername != null);
-    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerPassword != null);
-    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerToken != null);
-    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenKeyName != null);
-    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
+    /* Custom Auth (with signing) connect - Websockets */
+    @Test
+    public void ConnIoT_CustomAuth_UC4()
+    {
+        assumeTrue(mqtt5IoTCoreHost != null);
+        assumeTrue(mqtt5IoTCoreRegion != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerUsername != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerPassword != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerToken != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenKeyName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
 
-    //     try {
-    //         AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
-    //         builder.withEndpoint(mqtt5IoTCoreHost);
-    //         String clientId = "test-" + UUID.randomUUID().toString();
-    //         builder.withClientId(clientId);
-    //         builder.withCustomAuthorizer(
-    //             mqtt5IoTCoreSigningAuthorizerUsername,
-    //             mqtt5IoTCoreSigningAuthorizerName,
-    //             mqtt5IoTCoreSigningAuthorizerTokenSignature,
-    //             mqtt5IoTCoreSigningAuthorizerPassword,
-    //             mqtt5IoTCoreSigningAuthorizerTokenKeyName,
-    //             mqtt5IoTCoreSigningAuthorizerToken);
-    //         builder.withWebsockets(true);
-    //         MqttClientConnection connection = builder.build();
-    //         builder.close();
+        try {
+            AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
+            builder.withEndpoint(mqtt5IoTCoreHost);
+            String clientId = "test-" + UUID.randomUUID().toString();
+            builder.withClientId(clientId);
+            builder.withCustomAuthorizer(
+                mqtt5IoTCoreSigningAuthorizerUsername,
+                mqtt5IoTCoreSigningAuthorizerName,
+                mqtt5IoTCoreSigningAuthorizerTokenSignature,
+                mqtt5IoTCoreSigningAuthorizerPassword,
+                mqtt5IoTCoreSigningAuthorizerTokenKeyName,
+                mqtt5IoTCoreSigningAuthorizerToken);
+            builder.withWebsockets(true);
+            builder.withWebsocketSigningRegion(mqtt5IoTCoreRegion);
+            MqttClientConnection connection = builder.build();
+            builder.close();
 
-    //         connection.connect().get();
-    //         connection.disconnect().get();
-    //         connection.close();
+            connection.connect().get();
+            connection.disconnect().get();
+            connection.close();
 
-    //     } catch (Exception ex) {
-    //         fail(ex);
-    //     }
-    // }
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
 }

--- a/sdk/tests/mqtt/MqttBuilderTest.java
+++ b/sdk/tests/mqtt/MqttBuilderTest.java
@@ -4,6 +4,9 @@
  */
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 
 import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
@@ -66,9 +69,11 @@ public class MqttBuilderTest {
         try {
             AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
             builder.withEndpoint(mqtt5IoTCoreHost);
+            String clientId = "test-" + UUID.randomUUID().toString();
+            builder.withClientId(clientId);
             builder.withCustomAuthorizer(
                 mqtt5IoTCoreNoSigningAuthorizerUsername,
-                mqtt5IoTCoreSigningAuthorizerName,
+                mqtt5IoTCoreNoSigningAuthorizerName,
                 null,
                 mqtt5IoTCoreNoSigningAuthorizerPassword,
                 null,
@@ -100,6 +105,8 @@ public class MqttBuilderTest {
         try {
             AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
             builder.withEndpoint(mqtt5IoTCoreHost);
+            String clientId = "test-" + UUID.randomUUID().toString();
+            builder.withClientId(clientId);
             builder.withCustomAuthorizer(
                 mqtt5IoTCoreSigningAuthorizerUsername,
                 mqtt5IoTCoreSigningAuthorizerName,
@@ -119,4 +126,74 @@ public class MqttBuilderTest {
         }
     }
 
+        /* Custom Auth (no signing) connect - Websockets */
+    @Test
+    public void ConnIoT_CustomAuth_UC3()
+    {
+        assumeTrue(mqtt5IoTCoreHost != null);
+        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerName != null);
+        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerUsername != null);
+        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerPassword != null);
+
+        try {
+            AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
+            builder.withEndpoint(mqtt5IoTCoreHost);
+            String clientId = "test-" + UUID.randomUUID().toString();
+            builder.withClientId(clientId);
+            builder.withCustomAuthorizer(
+                mqtt5IoTCoreNoSigningAuthorizerUsername,
+                mqtt5IoTCoreNoSigningAuthorizerName,
+                null,
+                mqtt5IoTCoreNoSigningAuthorizerPassword,
+                null,
+                null);
+            builder.withWebsockets(true);
+            MqttClientConnection connection = builder.build();
+            builder.close();
+
+            connection.connect().get();
+            connection.disconnect().get();
+            connection.close();
+
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
+
+    /* Custom Auth (with signing) connect - Websockets */
+    @Test
+    public void ConnIoT_CustomAuth_UC4()
+    {
+        assumeTrue(mqtt5IoTCoreHost != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerUsername != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerPassword != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerToken != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenKeyName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
+
+        try {
+            AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
+            builder.withEndpoint(mqtt5IoTCoreHost);
+            String clientId = "test-" + UUID.randomUUID().toString();
+            builder.withClientId(clientId);
+            builder.withCustomAuthorizer(
+                mqtt5IoTCoreSigningAuthorizerUsername,
+                mqtt5IoTCoreSigningAuthorizerName,
+                mqtt5IoTCoreSigningAuthorizerTokenSignature,
+                mqtt5IoTCoreSigningAuthorizerPassword,
+                mqtt5IoTCoreSigningAuthorizerTokenKeyName,
+                mqtt5IoTCoreSigningAuthorizerToken);
+            builder.withWebsockets(true);
+            MqttClientConnection connection = builder.build();
+            builder.close();
+
+            connection.connect().get();
+            connection.disconnect().get();
+            connection.close();
+
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
 }

--- a/sdk/tests/mqtt/MqttBuilderTest.java
+++ b/sdk/tests/mqtt/MqttBuilderTest.java
@@ -128,7 +128,7 @@ public class MqttBuilderTest {
         }
     }
 
-        /* Custom Auth (no signing) connect - Websockets */
+    /* Custom Auth (no signing) connect - Websockets */
     @Test
     public void ConnIoT_CustomAuth_UC3()
     {

--- a/sdk/tests/mqtt/MqttBuilderTest.java
+++ b/sdk/tests/mqtt/MqttBuilderTest.java
@@ -127,73 +127,73 @@ public class MqttBuilderTest {
     }
 
         /* Custom Auth (no signing) connect - Websockets */
-    @Test
-    public void ConnIoT_CustomAuth_UC3()
-    {
-        assumeTrue(mqtt5IoTCoreHost != null);
-        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerName != null);
-        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerUsername != null);
-        assumeTrue(mqtt5IoTCoreNoSigningAuthorizerPassword != null);
+    // @Test
+    // public void ConnIoT_CustomAuth_UC3()
+    // {
+    //     assumeTrue(mqtt5IoTCoreHost != null);
+    //     assumeTrue(mqtt5IoTCoreNoSigningAuthorizerName != null);
+    //     assumeTrue(mqtt5IoTCoreNoSigningAuthorizerUsername != null);
+    //     assumeTrue(mqtt5IoTCoreNoSigningAuthorizerPassword != null);
 
-        try {
-            AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
-            builder.withEndpoint(mqtt5IoTCoreHost);
-            String clientId = "test-" + UUID.randomUUID().toString();
-            builder.withClientId(clientId);
-            builder.withCustomAuthorizer(
-                mqtt5IoTCoreNoSigningAuthorizerUsername,
-                mqtt5IoTCoreNoSigningAuthorizerName,
-                null,
-                mqtt5IoTCoreNoSigningAuthorizerPassword,
-                null,
-                null);
-            builder.withWebsockets(true);
-            MqttClientConnection connection = builder.build();
-            builder.close();
+    //     try {
+    //         AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
+    //         builder.withEndpoint(mqtt5IoTCoreHost);
+    //         String clientId = "test-" + UUID.randomUUID().toString();
+    //         builder.withClientId(clientId);
+    //         builder.withCustomAuthorizer(
+    //             mqtt5IoTCoreNoSigningAuthorizerUsername,
+    //             mqtt5IoTCoreNoSigningAuthorizerName,
+    //             null,
+    //             mqtt5IoTCoreNoSigningAuthorizerPassword,
+    //             null,
+    //             null);
+    //         builder.withWebsockets(true);
+    //         MqttClientConnection connection = builder.build();
+    //         builder.close();
 
-            connection.connect().get();
-            connection.disconnect().get();
-            connection.close();
+    //         connection.connect().get();
+    //         connection.disconnect().get();
+    //         connection.close();
 
-        } catch (Exception ex) {
-            fail(ex);
-        }
-    }
+    //     } catch (Exception ex) {
+    //         fail(ex);
+    //     }
+    // }
 
-    /* Custom Auth (with signing) connect - Websockets */
-    @Test
-    public void ConnIoT_CustomAuth_UC4()
-    {
-        assumeTrue(mqtt5IoTCoreHost != null);
-        assumeTrue(mqtt5IoTCoreSigningAuthorizerName != null);
-        assumeTrue(mqtt5IoTCoreSigningAuthorizerUsername != null);
-        assumeTrue(mqtt5IoTCoreSigningAuthorizerPassword != null);
-        assumeTrue(mqtt5IoTCoreSigningAuthorizerToken != null);
-        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenKeyName != null);
-        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
+    // /* Custom Auth (with signing) connect - Websockets */
+    // @Test
+    // public void ConnIoT_CustomAuth_UC4()
+    // {
+    //     assumeTrue(mqtt5IoTCoreHost != null);
+    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerName != null);
+    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerUsername != null);
+    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerPassword != null);
+    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerToken != null);
+    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenKeyName != null);
+    //     assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
 
-        try {
-            AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
-            builder.withEndpoint(mqtt5IoTCoreHost);
-            String clientId = "test-" + UUID.randomUUID().toString();
-            builder.withClientId(clientId);
-            builder.withCustomAuthorizer(
-                mqtt5IoTCoreSigningAuthorizerUsername,
-                mqtt5IoTCoreSigningAuthorizerName,
-                mqtt5IoTCoreSigningAuthorizerTokenSignature,
-                mqtt5IoTCoreSigningAuthorizerPassword,
-                mqtt5IoTCoreSigningAuthorizerTokenKeyName,
-                mqtt5IoTCoreSigningAuthorizerToken);
-            builder.withWebsockets(true);
-            MqttClientConnection connection = builder.build();
-            builder.close();
+    //     try {
+    //         AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder();
+    //         builder.withEndpoint(mqtt5IoTCoreHost);
+    //         String clientId = "test-" + UUID.randomUUID().toString();
+    //         builder.withClientId(clientId);
+    //         builder.withCustomAuthorizer(
+    //             mqtt5IoTCoreSigningAuthorizerUsername,
+    //             mqtt5IoTCoreSigningAuthorizerName,
+    //             mqtt5IoTCoreSigningAuthorizerTokenSignature,
+    //             mqtt5IoTCoreSigningAuthorizerPassword,
+    //             mqtt5IoTCoreSigningAuthorizerTokenKeyName,
+    //             mqtt5IoTCoreSigningAuthorizerToken);
+    //         builder.withWebsockets(true);
+    //         MqttClientConnection connection = builder.build();
+    //         builder.close();
 
-            connection.connect().get();
-            connection.disconnect().get();
-            connection.close();
+    //         connection.connect().get();
+    //         connection.disconnect().get();
+    //         connection.close();
 
-        } catch (Exception ex) {
-            fail(ex);
-        }
-    }
+    //     } catch (Exception ex) {
+    //         fail(ex);
+    //     }
+    // }
 }

--- a/sdk/tests/mqtt5/Mqtt5BuilderTest.java
+++ b/sdk/tests/mqtt5/Mqtt5BuilderTest.java
@@ -310,9 +310,9 @@ public class Mqtt5BuilderTest {
         assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
 
         AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig customAuthConfig = new AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig();
-        customAuthConfig.authorizerName = mqtt5IoTCoreNoSigningAuthorizerName;
-        customAuthConfig.username = mqtt5IoTCoreNoSigningAuthorizerUsername;
-        customAuthConfig.password = mqtt5IoTCoreNoSigningAuthorizerPassword.getBytes();
+        customAuthConfig.authorizerName = mqtt5IoTCoreSigningAuthorizerName;
+        customAuthConfig.username = mqtt5IoTCoreSigningAuthorizerUsername;
+        customAuthConfig.password = mqtt5IoTCoreSigningAuthorizerPassword.getBytes();
         customAuthConfig.tokenValue = mqtt5IoTCoreSigningAuthorizerToken;
         customAuthConfig.tokenKeyName = mqtt5IoTCoreSigningAuthorizerTokenKeyName;
         customAuthConfig.tokenSignature = mqtt5IoTCoreSigningAuthorizerTokenSignature;
@@ -374,9 +374,9 @@ public class Mqtt5BuilderTest {
         assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
 
         AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig customAuthConfig = new AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig();
-        customAuthConfig.authorizerName = mqtt5IoTCoreNoSigningAuthorizerName;
-        customAuthConfig.username = mqtt5IoTCoreNoSigningAuthorizerUsername;
-        customAuthConfig.password = mqtt5IoTCoreNoSigningAuthorizerPassword.getBytes();
+        customAuthConfig.authorizerName = mqtt5IoTCoreSigningAuthorizerName;
+        customAuthConfig.username = mqtt5IoTCoreSigningAuthorizerUsername;
+        customAuthConfig.password = mqtt5IoTCoreSigningAuthorizerPassword.getBytes();
         customAuthConfig.tokenValue = mqtt5IoTCoreSigningAuthorizerToken;
         customAuthConfig.tokenKeyName = mqtt5IoTCoreSigningAuthorizerTokenKeyName;
         customAuthConfig.tokenSignature = mqtt5IoTCoreSigningAuthorizerTokenSignature;

--- a/sdk/tests/mqtt5/Mqtt5BuilderTest.java
+++ b/sdk/tests/mqtt5/Mqtt5BuilderTest.java
@@ -442,15 +442,15 @@ public class Mqtt5BuilderTest {
         assumeTrue(mqtt5IoTCoreSigningAuthorizerName != null);
         assumeTrue(mqtt5IoTCoreSigningAuthorizerUsername != null);
         assumeTrue(mqtt5IoTCoreSigningAuthorizerPassword != null);
-        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenKeyName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerToken != null);
         assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
 
         AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig customAuthConfig = new AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig();
         customAuthConfig.authorizerName = mqtt5IoTCoreSigningAuthorizerName;
         customAuthConfig.username = mqtt5IoTCoreSigningAuthorizerUsername;
         customAuthConfig.password = mqtt5IoTCoreSigningAuthorizerPassword.getBytes();
-        customAuthConfig.tokenValue = "Invalid Token";
-        customAuthConfig.tokenKeyName = mqtt5IoTCoreSigningAuthorizerTokenKeyName;
+        customAuthConfig.tokenValue = mqtt5IoTCoreSigningAuthorizerToken;
+        customAuthConfig.tokenKeyName = "Invalid Token";
         customAuthConfig.tokenSignature = mqtt5IoTCoreSigningAuthorizerTokenSignature;
 
         AwsIotMqtt5ClientBuilder builder = AwsIotMqtt5ClientBuilder.newWebsocketMqttBuilderWithCustomAuth(

--- a/sdk/tests/mqtt5/Mqtt5BuilderTest.java
+++ b/sdk/tests/mqtt5/Mqtt5BuilderTest.java
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -392,6 +393,117 @@ public class Mqtt5BuilderTest {
 
         Mqtt5Client client = builder.build();
         TestSubPubUnsub(client, lifecycleEvents, publishEvents);
+        client.close();
+        builder.close();
+    }
+
+    /* Custom Auth (with signing) connect - Websockets - Invalid Password */
+    @Test
+    public void ConnIoT_CustomAuth_InvalidPassword()
+    {
+        assumeTrue(mqtt5IoTCoreHost != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerUsername != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerToken != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenKeyName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
+
+        AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig customAuthConfig = new AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig();
+        customAuthConfig.authorizerName = mqtt5IoTCoreSigningAuthorizerName;
+        customAuthConfig.username = mqtt5IoTCoreSigningAuthorizerUsername;
+        customAuthConfig.password = "InvalidPassword".getBytes();
+        customAuthConfig.tokenValue = mqtt5IoTCoreSigningAuthorizerToken;
+        customAuthConfig.tokenKeyName = mqtt5IoTCoreSigningAuthorizerTokenKeyName;
+        customAuthConfig.tokenSignature = mqtt5IoTCoreSigningAuthorizerTokenSignature;
+
+        AwsIotMqtt5ClientBuilder builder = AwsIotMqtt5ClientBuilder.newWebsocketMqttBuilderWithCustomAuth(
+            mqtt5IoTCoreHost, customAuthConfig);
+
+        LifecycleEvents_Futured lifecycleEvents = new LifecycleEvents_Futured();
+        builder.withLifeCycleEvents(lifecycleEvents);
+
+        PublishEvents_Futured publishEvents = new PublishEvents_Futured();
+        builder.withPublishEvents(publishEvents);
+
+        Mqtt5Client client = builder.build();
+
+        client.start();
+        assertThrows(Exception.class, () -> lifecycleEvents.connectedFuture.get(120, TimeUnit.SECONDS));
+
+        client.close();
+        builder.close();
+    }
+
+    /* Custom Auth (with signing) connect - Websockets - Invalid Token */
+    @Test
+    public void ConnIoT_CustomAuth_InvalidToken()
+    {
+        assumeTrue(mqtt5IoTCoreHost != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerUsername != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerPassword != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenKeyName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenSignature != null);
+
+        AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig customAuthConfig = new AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig();
+        customAuthConfig.authorizerName = mqtt5IoTCoreSigningAuthorizerName;
+        customAuthConfig.username = mqtt5IoTCoreSigningAuthorizerUsername;
+        customAuthConfig.password = mqtt5IoTCoreSigningAuthorizerPassword.getBytes();
+        customAuthConfig.tokenValue = "Invalid Token";
+        customAuthConfig.tokenKeyName = mqtt5IoTCoreSigningAuthorizerTokenKeyName;
+        customAuthConfig.tokenSignature = mqtt5IoTCoreSigningAuthorizerTokenSignature;
+
+        AwsIotMqtt5ClientBuilder builder = AwsIotMqtt5ClientBuilder.newWebsocketMqttBuilderWithCustomAuth(
+            mqtt5IoTCoreHost, customAuthConfig);
+
+        LifecycleEvents_Futured lifecycleEvents = new LifecycleEvents_Futured();
+        builder.withLifeCycleEvents(lifecycleEvents);
+
+        PublishEvents_Futured publishEvents = new PublishEvents_Futured();
+        builder.withPublishEvents(publishEvents);
+
+        Mqtt5Client client = builder.build();
+
+        client.start();
+        assertThrows(Exception.class, () -> lifecycleEvents.connectedFuture.get(120, TimeUnit.SECONDS));
+
+        client.close();
+        builder.close();
+    }
+
+    /* Custom Auth (with signing) connect - Websockets - Invalid Token Signature */
+    @Test
+    public void ConnIoT_CustomAuth_InvalidTokenSignature()
+    {
+        assumeTrue(mqtt5IoTCoreHost != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerName != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerUsername != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerPassword != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerToken != null);
+        assumeTrue(mqtt5IoTCoreSigningAuthorizerTokenKeyName != null);
+
+        AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig customAuthConfig = new AwsIotMqtt5ClientBuilder.MqttConnectCustomAuthConfig();
+        customAuthConfig.authorizerName = mqtt5IoTCoreSigningAuthorizerName;
+        customAuthConfig.username = mqtt5IoTCoreSigningAuthorizerUsername;
+        customAuthConfig.password = mqtt5IoTCoreSigningAuthorizerPassword.getBytes();
+        customAuthConfig.tokenValue = mqtt5IoTCoreSigningAuthorizerToken;
+        customAuthConfig.tokenKeyName = mqtt5IoTCoreSigningAuthorizerTokenKeyName;
+        customAuthConfig.tokenSignature = "InvalidTokenSignature";
+
+        AwsIotMqtt5ClientBuilder builder = AwsIotMqtt5ClientBuilder.newWebsocketMqttBuilderWithCustomAuth(
+            mqtt5IoTCoreHost, customAuthConfig);
+
+        LifecycleEvents_Futured lifecycleEvents = new LifecycleEvents_Futured();
+        builder.withLifeCycleEvents(lifecycleEvents);
+
+        PublishEvents_Futured publishEvents = new PublishEvents_Futured();
+        builder.withPublishEvents(publishEvents);
+
+        Mqtt5Client client = builder.build();
+
+        client.start();
+        assertThrows(Exception.class, () -> lifecycleEvents.connectedFuture.get(120, TimeUnit.SECONDS));
+
         client.close();
         builder.close();
     }


### PR DESCRIPTION
- Enable MQTT311 Custom Auth tests.
- Implement MQTT311 Custom Auth over WebSockets tests.
- Fix MQTT5 Custom Auth tests with signing authorizer.
- Implement MQTT311 and MQTT5 Custom Auth tests for invalid creds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
