### PR TITLE
Update crt version script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,7 +429,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Consistent aws-crt version
         run: |
-          ./update-crt.py --check-consistency
+          ./update-crt.py --check_consistency
 
   check-codegen-edits:
     runs-on: ubuntu-20.04 # latest

--- a/samples/Mqtt5/PubSub/pom.xml
+++ b/samples/Mqtt5/PubSub/pom.xml
@@ -27,7 +27,7 @@
                 <dependency>
                     <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
                     <artifactId>aws-iot-device-sdk</artifactId>
-                    <version>1.11.0</version>
+                    <version>1.17.2</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/samples/Mqtt5/SharedSubscription/pom.xml
+++ b/samples/Mqtt5/SharedSubscription/pom.xml
@@ -27,7 +27,7 @@
                 <dependency>
                     <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
                     <artifactId>aws-iot-device-sdk</artifactId>
-                    <version>1.11.0</version>
+                    <version>1.17.2</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/update-crt.py
+++ b/update-crt.py
@@ -5,13 +5,27 @@ import os
 import re
 import subprocess
 
+## USER GUIDE
+## update-crt.py is used for the following purposes : 1. update crt version 2. update sdk version 3. Check version consistency
+## Examples:
+## 1. `Python update-crt.py`
+##     Update the crt version in the sdk library to latest crt version released on Github
+## 2. `Python update-crt.py <VERSION STRING>`
+##     Update the crt version in the sdk library to <VERSION STRING>
+## 3. `Python update-crt.py --update_samples --update_sdk_text`
+##     Update the sdk version to latest sdk version released on Github. The command would not update crt version.
+## 4. `Python update-crt.py <VERSION STRING> --update_samples --update_sdk_text`
+##     Update the sdk version to <VERSION STRING> in samples and README. The command would not update crt version.
+## 5. `Python update-crt.py --check_consistency`
+##     Make sure crt and sdk version specified in the files are consistent. The script will not update any file with this option.
+
 VERSION_PATTERN = '\d+\.\d+\.\d+'
 
 parser = argparse.ArgumentParser(
     description="Update files containing hard-coded aws-crt-java version numbers.")
 parser.add_argument('version', nargs='?',
                     help='version to use (i.e. "0.1.2"). default: automatically detect latest version')
-parser.add_argument('--check-consistency', action='store_true',
+parser.add_argument('--check_consistency', action='store_true',
                     help='Exit with error if version is inconsistent between files')
 parser.add_argument('--update_samples', action='store_true',
                     help="Update the SDK samples to the latest SDK release OR to the passed in version")
@@ -19,26 +33,31 @@ parser.add_argument('--update_sdk_text', action='store_true',
                     help="Update the SDK text (readme, etc) to the latest SDK release OR to the passed in version")
 args = parser.parse_args()
 
+consistency_version = None
 
 def main():
-    if args.check_consistency:
-        # we'll find the version from the first file we scan
-        args.version = None
-    else:
-        if args.version is None:
-            args.version = get_latest_github_version("https://github.com/awslabs/aws-crt-java.git")
-            print(f'Latest CRT version: {args.version}')
+    sdk_version = args.version
+    update_sdk = False
+    if args.version is None:
+        args.version = get_latest_github_version("https://github.com/awslabs/aws-crt-java.git")
+        print(f'Latest CRT version: {args.version}')
+        sdk_version = get_latest_github_version("https://github.com/aws/aws-iot-device-sdk-java-v2.git")
+        print (f"Latest SDK version: {sdk_version}")
 
-        if re.fullmatch(VERSION_PATTERN, args.version) is None:
-            exit(f'Invalid version: "{args.version}". Must look like "0.1.2"')
+    if re.fullmatch(VERSION_PATTERN, args.version) is None:
+        exit(f'Invalid version: "{args.version}". Must look like "0.1.2"')
 
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    if args.update_samples == True:
-        update_samples()
-    elif args.update_sdk_text == True:
-        sdk_version = args.version
-        print (f"Latest SDK version: {sdk_version}")
+
+    # Update SDK version in specified section
+    if args.update_samples or args.check_consistency:
+        print (f"Update samples to latest SDK version: {sdk_version}")
+        update_samples(sdk_version)
+        update_sdk = True
+
+    if args.update_sdk_text or args.check_consistency:
+        print (f"Update docs to latest SDK version: {sdk_version}")
         update(filepath='README.md',
             preceded_by=r'<artifactId>aws-iot-device-sdk</artifactId>\s*<version>',
             followed_by=r'</version>',
@@ -51,19 +70,19 @@ def main():
             preceded_by=r"Replace .* in `<version>",
             followed_by=r"</version>` with the latest release version for the SDK.",
             force_version=sdk_version)
-    else:
+        update_sdk = True
+
+    # Update CRT versions if not specified
+    if not update_sdk or args.check_consistency:
+        # Reset consistency_version for CRT version check
+        global consistency_version
+        consistency_version = None
         update(filepath='sdk/pom.xml',
             preceded_by=r'<artifactId>aws-crt</artifactId>\s*<version>',
             followed_by=r'</version>')
-        update(filepath='README.md',
-            preceded_by=r'--branch v',
-            followed_by=r' .*aws-crt-java.git')
         update(filepath='android/iotdevicesdk/build.gradle',
             preceded_by=r"api 'software.amazon.awssdk.crt:aws-crt-android:",
             followed_by=r"'")
-        update(filepath='README.md',
-            preceded_by=r'Use the latest version of the CRT here instead of ".*',
-            followed_by=r'"')
 
 
 def update(*, filepath, preceded_by, followed_by, force_version=None):
@@ -87,15 +106,16 @@ def update(*, filepath, preceded_by, followed_by, force_version=None):
             exit(f'Version not found in: {filepath}\n' +
                  f'Preceded by: "{preceded_by}"')
 
-        if args.check_consistency and force_version == None:
+        if args.check_consistency:
             # in --check-consistency mode we remember the version from the first
             # file we scan, and then ensure all subsequent files use that version too
             for match in matches:
                 found_version = match[1]
-                if args.version is None:
+                global consistency_version
+                if consistency_version is None:
                     print(f'Found version {found_version} in: {filepath}')
-                    args.version = found_version
-                elif found_version != args.version:
+                    consistency_version = found_version
+                elif found_version != consistency_version:
                     exit(f'Found different version {found_version} in: {filepath}')
         else:
             # running in normal mode, update the file
@@ -105,10 +125,7 @@ def update(*, filepath, preceded_by, followed_by, force_version=None):
             f.truncate()
 
 
-def update_samples():
-    sdk_version = args.version
-    print (f"Latest SDK version: {sdk_version}")
-
+def update_samples(sdk_version):
     sample_folders = [x[0] for x in os.walk("samples")]
     for sample_folder in sample_folders:
         sample_files = os.walk(sample_folder).__next__()[2]

--- a/utils/publish-release.sh
+++ b/utils/publish-release.sh
@@ -50,10 +50,10 @@ git checkout -b ${new_version_branch}
 
 # Go from utils to the main folder
 cd ..
-# Update the SDK version text and the SDK version in samples
+# Update the CRT version to latest release
 python3 ./update-crt.py
-python3 ./update-crt.py ${new_version} --update_sdk_text
-python3 ./update-crt.py ${new_version} --update_samples
+# Update the SDK version text and the SDK version in samples
+python3 ./update-crt.py ${new_version} --update_sdk_text --update_samples
 # Update the version in the README to show the latest
 sed -i -r "s/.*Latest released version:.*/Latest released version: v${new_version}/" README.md
 # Not sure how to do this better, so just add each file individually


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- `check_consistency` previously only checked for either CRT version or SDK version. Update the script so it would now check for both versions. 
- Removed two README sections as the text is removed from README from:
https://github.com/aws/aws-iot-device-sdk-java-v2/pull/486

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
