### PR TITLE
Don't update CRT version in Release Action

### DIFF
--- a/utils/publish-release.sh
+++ b/utils/publish-release.sh
@@ -50,8 +50,6 @@ git checkout -b ${new_version_branch}
 
 # Go from utils to the main folder
 cd ..
-# Update the CRT version to latest release
-python3 ./update-crt.py
 # Update the SDK version text and the SDK version in samples
 python3 ./update-crt.py ${new_version} --update_sdk_text --update_samples
 # Update the version in the README to show the latest


### PR DESCRIPTION
Release action should not automatically update CRT version. CRT version updates should be checked by CI to insure nothing breaks before being applied to the SDK.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
