### PR TITLE
Update Maven Deployment Script

### DIFF
--- a/codebuild/cd/test-snapshot.yml
+++ b/codebuild/cd/test-snapshot.yml
@@ -31,7 +31,7 @@ phases:
       # Verify that the package can be found in the snapshot repo
       # note that this uses an ancient version of maven and the maven dependency plugin because we're on trusty
       # http://maven.apache.org/plugins-archives/maven-dependency-plugin-2.1/get-mojo.html
-      - mvn -B dependency:get -DrepoUrl=https://aws.oss.sonatype.org/content/repositories/snapshots -Dartifact=software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk:${PKG_VERSION}-SNAPSHOT -Dtransitive=false
+      - mvn -B dependency:get -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots -Dartifact=software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk:${PKG_VERSION}-SNAPSHOT -Dtransitive=false
 
       # Run PubSub sample
       - mvn install -Dmaven.test.skip=true

--- a/codebuild/cd/test-snapshot.yml
+++ b/codebuild/cd/test-snapshot.yml
@@ -29,8 +29,9 @@ phases:
   build:
     commands:
       # Verify that the package can be found in the snapshot repo
-      # note that this uses an ancient version of maven and the maven dependency plugin because we're on trusty
-      # http://maven.apache.org/plugins-archives/maven-dependency-plugin-2.1/get-mojo.html
+      # https://maven.apache.org/plugins/maven-dependency-plugin/get-mojo.html
+      # The version of maven-dependency-plugin depends on the Codebuild environment.
+      # Codebuild is using maven-dependency-plugin:3.6.0 with image aws/codebuild/standard:6.0.
       - mvn -B dependency:get -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots -Dartifact=software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk:${PKG_VERSION}-SNAPSHOT -Dtransitive=false
 
       # Run PubSub sample


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Deprecate parameter `repoUrl`. 
Checkout the maven dependency doc here: 
https://maven.apache.org/plugins-archives/maven-dependency-plugin-2.8/get-mojo.html#remoteRepositories

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
