### PR TITLE
Add default ping timeout to 29000ms to MQTT5 Builder

### DIFF
--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
@@ -40,7 +40,8 @@ import software.amazon.awssdk.crt.utils.PackageInfo;
 public class AwsIotMqtt5ClientBuilder extends software.amazon.awssdk.crt.CrtResource {
     private static Long DEFAULT_WEBSOCKET_MQTT_PORT = 443L;
     private static Long DEFAULT_DIRECT_MQTT_PORT = 8883L;
-    private static Long DEFAULT_KEEP_ALIVE = 1200L;
+    private static Long DEFAULT_KEEP_ALIVE_SEC = 1200L;
+    private static Long DEFAULT_PING_TIMEOUT_MS = 29000L;
 
     private Mqtt5ClientOptionsBuilder config;
     private ConnectPacketBuilder configConnect;
@@ -51,8 +52,9 @@ public class AwsIotMqtt5ClientBuilder extends software.amazon.awssdk.crt.CrtReso
         config = new Mqtt5ClientOptionsBuilder(hostName, port);
         configTls = tlsContext;
         configConnect = new ConnectPacketBuilder();
-        configConnect.withKeepAliveIntervalSeconds(DEFAULT_KEEP_ALIVE);
+        configConnect.withKeepAliveIntervalSeconds(DEFAULT_KEEP_ALIVE_SEC);
         config.withExtendedValidationAndFlowControlOptions(Mqtt5ClientOptions.ExtendedValidationAndFlowControlOptions.AWS_IOT_CORE_DEFAULTS);
+        config.withPingTimeoutMs(DEFAULT_PING_TIMEOUT_MS);
         addReferenceTo(configTls);
     }
 
@@ -888,7 +890,7 @@ public class AwsIotMqtt5ClientBuilder extends software.amazon.awssdk.crt.CrtReso
             }
 
             addToUsernameParam(paramList, "x-amz-customauthorizer-name", config.authorizerName);
-            
+
             if (usingSigning == true) {
                 addToUsernameParam(paramList, config.tokenKeyName, config.tokenValue);
 


### PR DESCRIPTION
Add default ping timeout to MQTT5 builder of 29000ms to allow use of IoT Core minimum Keep Alive Timeout without validation error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
