### PR TITLE
Drop Android Min SDK to 24

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.1.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -1,7 +1,7 @@
 import java.util.regex.Pattern
 
 apply plugin: 'com.android.library'
-apply plugin: 'signing' // Needed for OpenPGP signatures required to publish to MAven Central Repository
+apply plugin: 'signing' // Needed for OpenPGP signatures required to publish to Maven Central Repository
 
 Properties getGitTag() {
     def gitTag = "git describe --tags".execute().text.trim()

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -47,7 +47,7 @@ android {
     buildToolsVersion "30.0.3"
 
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 24
         targetSdkVersion 30
         versionCode = gitVersionCode()
         versionName = gitVersionName()

--- a/android/iotdevicesdk/src/main/AndroidManifest.xml
+++ b/android/iotdevicesdk/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="software.amazon.awssdk.iotdevicesdk" />
+    package="software.amazon.awssdk.iotdevicesdk">
+</manifest>

--- a/samples/Android/app/build.gradle
+++ b/samples/Android/app/build.gradle
@@ -52,7 +52,6 @@ android {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
     }
-    ndkVersion '23.1.7779620'
 }
 
 dependencies {

--- a/samples/Android/app/build.gradle
+++ b/samples/Android/app/build.gradle
@@ -1,12 +1,10 @@
 buildscript {
-    ext.kotlin_version = '1.5.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.1.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -17,7 +15,6 @@ repositories {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 30
@@ -61,7 +58,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    api 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk-android:1.20.0'
+    api 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk-android:1.0.0-API24'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core:1.2.0'
     implementation 'androidx.core:core-ktx:1.2.0'

--- a/samples/Android/app/build.gradle
+++ b/samples/Android/app/build.gradle
@@ -26,7 +26,6 @@ android {
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
-        ndkVersion "23.1.7779620"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/samples/Android/app/build.gradle
+++ b/samples/Android/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
     defaultConfig {
         applicationId "software.amazon.awssdk.iotsamples"
-        minSdkVersion 26
+        minSdkVersion 24
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/samples/Android/app/build.gradle
+++ b/samples/Android/app/build.gradle
@@ -58,7 +58,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    api 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk-android:1.0.0-API24'
+    api 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk-android:1.20.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core:1.2.0'
     implementation 'androidx.core:core-ktx:1.2.0'


### PR DESCRIPTION
Reduce Min Android SDK version from 26 to 24


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
