### PR TITLE
Restore Android SDK to using latest version of Android Crt

### DIFF
--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -97,7 +97,7 @@ repositories {
 }
 
 dependencies {
-    api 'software.amazon.awssdk.crt:aws-crt-android:0.29.11'
+    api 'software.amazon.awssdk.crt:aws-crt-android:0.29.19'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.google.code.gson:gson:2.9.0'

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.29.18</version>
+      <version>0.29.19</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Restore Android SDK dependency of Android CRT to latest version of the CRT.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
