### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.58
+  BUILDER_VERSION: v0.9.60
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-iot-device-sdk-java-v2

--- a/builder.json
+++ b/builder.json
@@ -31,7 +31,9 @@
         "linux": {
             "architectures": {
                 "armv7": {
-                    "!packages": []
+                    "!packages": [
+                        "maven"
+                    ]
                 }
             }
         }

--- a/builder.json
+++ b/builder.json
@@ -27,6 +27,15 @@
             "!packages": []
         }
     },
+    "targets": {
+        "linux": {
+            "architectures": {
+                "armv7": {
+                    "!packages": []
+                }
+            }
+        }
+    },
     "variants" : {
         "skip_test": {
             "!test_steps": []


### PR DESCRIPTION
This PR fixes issues with manylinux2014 and raspberry CI jobs.

CI using our manylinux2014 docker image is failing with:
> Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container

Solution is based on https://github.com/awslabs/aws-crt-java/pull/804

CI for raspberry is failing with:
> E: Unable to locate package openjdk-8-jdk-headless

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
