### PR TITLE
Remove the dependency on Appcompat from `aws-iot-device-sdk-android`

### DIFF
--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -101,7 +101,6 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.google.code.gson:gson:2.9.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
Appcompat is only used for the tests, the library does not need it.

*Issue #, if available:*

*Description of changes:*
`aws-iot-device-sdk-android` is currently pulling `androidx.appcompat:appcompat`, but it is not using it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
