### PR TITLE
CI Fix

### DIFF
--- a/.github/workflows/DELETEME.txt
+++ b/.github/workflows/DELETEME.txt
@@ -1,0 +1,1 @@
+Delete me when done.

--- a/.github/workflows/DELETEME.txt
+++ b/.github/workflows/DELETEME.txt
@@ -1,1 +1,0 @@
-Delete me when done.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v3.14.1
       with:
-        distribution: temurin
+        distribution: ${{ matrix.version == 8 && 'corretto' || 'temurin' }}
         java-version: ${{ matrix.version }}
         cache: maven
     - name: Build ${{ env.PACKAGE_NAME }} + consumers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Checkout Sources
       uses: actions/checkout@v2
     - name: Setup Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: ${{ matrix.version }}
@@ -130,7 +130,7 @@ jobs:
     - name: Checkout Sources
       uses: actions/checkout@v2
     - name: Setup Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: ${{ matrix.version }}
@@ -219,7 +219,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.version }}
@@ -292,7 +292,7 @@ jobs:
             submodules: true
       # Setup JDK 11
       - name: set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -386,7 +386,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Checkout Sources
       uses: actions/checkout@v2
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v3.14.1
       with:
         distribution: temurin
         java-version: ${{ matrix.version }}
@@ -130,7 +130,7 @@ jobs:
     - name: Checkout Sources
       uses: actions/checkout@v2
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v3.14.1
       with:
         distribution: temurin
         java-version: ${{ matrix.version }}
@@ -219,7 +219,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3.14.1
         with:
           distribution: temurin
           java-version: ${{ matrix.version }}
@@ -292,7 +292,7 @@ jobs:
             submodules: true
       # Setup JDK 11
       - name: set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3.14.1
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -386,7 +386,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3.14.1
         with:
           distribution: temurin
           java-version: ${{ matrix.version }}


### PR DESCRIPTION
CI was failing due to a number of reasons:

actions/setup-java@v2 had its cache backend shut off on 4/15/2025 resulting in HTTP 422.
Updated them to setup-java@v3.14.0 which bumps the dependency to @actions/cache v4.0.3. This also bumps the Node version used from 12 to 16 but that seems unavoidable if we continue to use setup-java.

v4 is also available but that bumps to Node 20 so we can stick with 3.14.0 for now.

Temurin 8 appears to not have support for macOS14 which was causing the osx-java-compat(8) to fail:
https://adoptium.net/supported-platforms/
For 8 on osx, we will use corretto for now. Both Temurin 8 and Corretto 8 are reported to end security maintenance in mid 2026 so we may need to revisit this at that point.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
