### PR TITLE
Fix migration guide rendering

### DIFF
--- a/documents/MIGRATION_GUIDE.md
+++ b/documents/MIGRATION_GUIDE.md
@@ -167,23 +167,23 @@ and other connection-related features.
 For more information, refer to the [How to set up MQTT5 builder based on desired connection method](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#how-to-setup-mqtt5-builder-based-on-desired-connection-method)
 section of the MQTT5 user guide for detailed information and code snippets on each connection type and connection feature.
 
-| Connection type/feature                                  | v1 SDK                                  | v2 SDK                           | User guide |
-|----------------------------------------------------------|-----------------------------------------|----------------------------------|:----------:|
-| MQTT over Secure WebSocket with AWS SigV4 authentication | $${\Large\color{green}&#10004}$$        | $${\Large\color{green}&#10004}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#websocket-connection-with-sigv4-authentication-method) |
-| MQTT with Java KeyStore Method                           | $${\Large\color{green}&#10004}$$        | $${\Large\color{green}&#10004}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-java-keystore-method) |
-| Websocket Connection with Cognito Authentication Method  | $${\Large\color{green}&#10004}$$          | $${\Large\color{green}&#10004}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#websocket-connection-with-cognito-authentication-method) |
-| MQTT with X.509 certificate based mutual authentication  | $${\Large\color{orange}&#10004\*}$$     | $${\Large\color{green}&#10004}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-x509-based-mutual-tls-method) |
-| MQTT with PKCS12 Method                                  | $${\Large\color{orange}&#10004\*}$$     | $${\Large\color{green}&#10004}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-pkcs12-method) |
-| MQTT with Custom Key Operation Method                    | $${\Large\color{orange}&#10004\*}$$     | $${\Large\color{green}&#10004}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-custom-key-operation-method) |
-| MQTT with Custom Authorizer Method                       | $${\Large\color{orange}&#10004\*\*}$$   | $${\Large\color{green}&#10004}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-custom-authorizer-method) |
-| MQTT with Windows Certificate Store Method               | $${\Large\color{red}&#10008}$$          | $${\Large\color{green}&#10004}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-windows-certificate-store-method) |
-| MQTT with PKCS11 Method                                  | $${\Large\color{red}&#10008}$$          | $${\Large\color{green}&#10004}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-pkcs11-method) |
-| HTTP Proxy                                               | $${\Large\color{orange}&#10004\*\*\*}$$ | $${\Large\color{green}&#10004}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#http-proxy) |
+| Connection type/feature                                  | v1 SDK                                   | v2 SDK                            | User guide |
+|----------------------------------------------------------|------------------------------------------|-----------------------------------|:----------:|
+| MQTT over Secure WebSocket with AWS SigV4 authentication | $${\Large\color{green}&#10004;}$$        | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#websocket-connection-with-sigv4-authentication-method) |
+| MQTT with Java KeyStore Method                           | $${\Large\color{green}&#10004;}$$        | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-java-keystore-method) |
+| Websocket Connection with Cognito Authentication Method  | $${\Large\color{green}&#10004;}$$        | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#websocket-connection-with-cognito-authentication-method) |
+| MQTT with X.509 certificate based mutual authentication  | $${\Large\color{orange}&#10004;\*}$$     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-x509-based-mutual-tls-method) |
+| MQTT with PKCS12 Method                                  | $${\Large\color{orange}&#10004;\*}$$     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-pkcs12-method) |
+| MQTT with Custom Key Operation Method                    | $${\Large\color{orange}&#10004;\*}$$     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-custom-key-operation-method) |
+| MQTT with Custom Authorizer Method                       | $${\Large\color{orange}&#10004;\*\*}$$   | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-custom-authorizer-method) |
+| MQTT with Windows Certificate Store Method               | $${\Large\color{red}&#10008;}$$          | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-windows-certificate-store-method) |
+| MQTT with PKCS11 Method                                  | $${\Large\color{red}&#10008;}$$          | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-pkcs11-method) |
+| HTTP Proxy                                               | $${\Large\color{orange}&#10004;\*\*\*}$$ | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#http-proxy) |
 
-${\Large\color{orange}&#10004\*}$ - To get this connection type work in the v1 SDK, you need to create KeyStore.\
-${\Large\color{orange}&#10004\*\*}$ - To get this connection type work in the v1 SDK, you need to implement the
+${\Large\color{orange}&#10004;\*}$ - To get this connection type work in the v1 SDK, you need to create KeyStore.\
+${\Large\color{orange}&#10004;\*\*}$ - To get this connection type work in the v1 SDK, you need to implement the
 [Custom Authentication workflow](https://docs.aws.amazon.com/iot/latest/developerguide/custom-authorizer.html).\
-${\Large\color{orange}&#10004\*\*\*}$ - The v1 SDK does not allow specifying HTTP proxy, but it is possible to configure
+${\Large\color{orange}&#10004;\*\*\*}$ - The v1 SDK does not allow specifying HTTP proxy, but it is possible to configure
 systemwide proxy.
 
 #### Example of creating connection using KeyStore in the v1 SDK

--- a/documents/MIGRATION_GUIDE.md
+++ b/documents/MIGRATION_GUIDE.md
@@ -167,23 +167,23 @@ and other connection-related features.
 For more information, refer to the [How to set up MQTT5 builder based on desired connection method](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#how-to-setup-mqtt5-builder-based-on-desired-connection-method)
 section of the MQTT5 user guide for detailed information and code snippets on each connection type and connection feature.
 
-| Connection type/feature                                  | v1 SDK                                   | v2 SDK                            | User guide |
-|----------------------------------------------------------|------------------------------------------|-----------------------------------|:----------:|
-| MQTT over Secure WebSocket with AWS SigV4 authentication | $${\Large\color{green}&#10004;}$$        | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#websocket-connection-with-sigv4-authentication-method) |
-| MQTT with Java KeyStore Method                           | $${\Large\color{green}&#10004;}$$        | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-java-keystore-method) |
-| Websocket Connection with Cognito Authentication Method  | $${\Large\color{green}&#10004;}$$        | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#websocket-connection-with-cognito-authentication-method) |
-| MQTT with X.509 certificate based mutual authentication  | $${\Large\color{orange}&#10004;\*}$$     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-x509-based-mutual-tls-method) |
-| MQTT with PKCS12 Method                                  | $${\Large\color{orange}&#10004;\*}$$     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-pkcs12-method) |
-| MQTT with Custom Key Operation Method                    | $${\Large\color{orange}&#10004;\*}$$     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-custom-key-operation-method) |
-| MQTT with Custom Authorizer Method                       | $${\Large\color{orange}&#10004;\*\*}$$   | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-custom-authorizer-method) |
-| MQTT with Windows Certificate Store Method               | $${\Large\color{red}&#10008;}$$          | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-windows-certificate-store-method) |
-| MQTT with PKCS11 Method                                  | $${\Large\color{red}&#10008;}$$          | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-pkcs11-method) |
-| HTTP Proxy                                               | $${\Large\color{orange}&#10004;\*\*\*}$$ | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#http-proxy) |
+| Connection type/feature                                  | v1 SDK                                              | v2 SDK                            | User guide |
+|----------------------------------------------------------|-----------------------------------------------------|-----------------------------------|:----------:|
+| MQTT over Secure WebSocket with AWS SigV4 authentication | $${\Large\color{green}&#10004;}$$                   | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#websocket-connection-with-sigv4-authentication-method) |
+| MQTT with Java KeyStore Method                           | $${\Large\color{green}&#10004;}$$                   | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-java-keystore-method) |
+| Websocket Connection with Cognito Authentication Method  | $${\Large\color{green}&#10004;}$$                   | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#websocket-connection-with-cognito-authentication-method) |
+| MQTT with X.509 certificate based mutual authentication  | $${\Large\color{orange}&#10004;}$$<sup>\*</sup>     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-x509-based-mutual-tls-method) |
+| MQTT with PKCS12 Method                                  | $${\Large\color{orange}&#10004;}$$<sup>\*</sup>     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-pkcs12-method) |
+| MQTT with Custom Key Operation Method                    | $${\Large\color{orange}&#10004;}$$<sup>\*</sup>     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-custom-key-operation-method) |
+| MQTT with Custom Authorizer Method                       | $${\Large\color{orange}&#10004;}$$<sup>\*\*</sup>   | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-custom-authorizer-method) |
+| MQTT with Windows Certificate Store Method               | $${\Large\color{red}&#10008;}$$                     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-windows-certificate-store-method) |
+| MQTT with PKCS11 Method                                  | $${\Large\color{red}&#10008;}$$                     | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#direct-mqtt-with-pkcs11-method) |
+| HTTP Proxy                                               | $${\Large\color{orange}&#10004;}$$<sup>\*\*\*</sup> | $${\Large\color{green}&#10004;}$$ | [link](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/documents/MQTT5_Userguide.md#http-proxy) |
 
-${\Large\color{orange}&#10004;\*}$ - To get this connection type work in the v1 SDK, you need to create KeyStore.\
-${\Large\color{orange}&#10004;\*\*}$ - To get this connection type work in the v1 SDK, you need to implement the
+${\Large\color{orange}&#10004;}$<sup>\*</sup> - To get this connection type work in the v1 SDK, you need to create KeyStore.\
+${\Large\color{orange}&#10004;}$<sup>\*\*</sup> - To get this connection type work in the v1 SDK, you need to implement the
 [Custom Authentication workflow](https://docs.aws.amazon.com/iot/latest/developerguide/custom-authorizer.html).\
-${\Large\color{orange}&#10004;\*\*\*}$ - The v1 SDK does not allow specifying HTTP proxy, but it is possible to configure
+${\Large\color{orange}&#10004;}$<sup>\*\*\*</sup> - The v1 SDK does not allow specifying HTTP proxy, but it is possible to configure
 systemwide proxy.
 
 #### Example of creating connection using KeyStore in the v1 SDK


### PR DESCRIPTION
*Issue #, if available:*

The rendering of the connection types table in the migration guide is [broken](https://github.com/aws/aws-iot-device-sdk-java-v2/blob/v1.25.0/documents/MIGRATION_GUIDE.md#connection-types-and-features).

*Description of changes:*

Properly specify UTF-8 symbol.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
