### PR TITLE
Android 16 KB page size support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,13 +290,18 @@ jobs:
         uses: actions/checkout@v2
         with:
             submodules: true
-      # Setup JDK 11
-      - name: set up JDK 11
-        uses: actions/setup-java@v3.14.1
+      # Setup JDK 17
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
+      # Ensure Gradle uses this JDK (important when toolchains are present)
+      - name: Point Gradle at JDK 17
+        run: echo "ORG_GRADLE_JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Mirror ANDROID_HOME → ANDROID_SDK_ROOT
+        run: echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> "$GITHUB_ENV"
       - name: Configure AWS credentials for Device Farm
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -314,6 +319,21 @@ jobs:
           cd sdk/tests/android/testapp/src/main/assets
           python3 -m pip install boto3
           python3 ./android_file_creation.py
+      
+      - name: Set Android keystore home
+        run: |
+          echo "ANDROID_SDK_HOME=$GITHUB_WORKSPACE/.android-home" >> "$GITHUB_ENV"
+          echo "ANDROID_PREFS_ROOT=$GITHUB_WORKSPACE/.android-home" >> "$GITHUB_ENV"
+          mkdir -p "$GITHUB_WORKSPACE/.android-home/.android"
+      - name: Create debug keystore
+        run: |
+          keytool -genkeypair \
+            -keystore "$ANDROID_SDK_HOME/.android/debug.keystore" \
+            -storepass android -keypass android \
+            -alias androiddebugkey \
+            -dname "CN=Android Debug,O=Android,C=US" \
+            -keyalg RSA -keysize 2048 -validity 14000
+
       - name: Build Test App
         run: |
           cd sdk/tests/android/testapp

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.2"
+        // AGP 8.5.1+ aligns uncompressed .so at 16KB automatically
+        // Requires JDK 17+
+        classpath "com.android.tools.build:gradle:8.5.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -43,16 +43,28 @@ ext {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    namespace "software.amazon.awssdk.iotdevicesdk"   // REQUIRED on AGP 8+
+
+    compileSdkVersion 35
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode = gitVersionCode()
         versionName = gitVersionName()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
+    }
+
+    buildFeatures { 
+        // AGP 8 disables buildConfig generation by default. We set this to true
+        // to resstore BuildConfig.VERSION_NAME for both debug and release build types.
+        buildConfig true 
+    }
+
+    // Make the 'release' SoftwareComponent available for publishing on AGP 8
+    publishing {
+        singleVariant("release") { withSourcesJar() }
     }
 
     sourceSets {
@@ -145,7 +157,10 @@ afterEvaluate {
 
         publications {
             release(MavenPublication) {
-                from components.release
+                def comp = components.findByName("release")
+                if (comp != null) {
+                    from comp
+                }
 
                 groupId = 'software.amazon.awssdk.iotdevicesdk'
                 artifactId = 'aws-iot-device-sdk-android'

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -97,7 +97,7 @@ repositories {
 }
 
 dependencies {
-    api 'software.amazon.awssdk.crt:aws-crt-android:0.38.7'
+    api 'software.amazon.awssdk.crt:aws-crt-android:0.38.11'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.google.code.gson:gson:2.9.0'

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -54,11 +54,11 @@ android {
         versionName = gitVersionName()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
-    }
 
-    aarMetadata {
+        aarMetadata {
         // Keeps from referencing newer resources/manifest attributes introduced after 30
         minCompileSdk = 30
+        }
     }
 
     buildFeatures { 

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -56,6 +56,11 @@ android {
         consumerProguardFiles 'consumer-rules.pro'
     }
 
+    aarMetadata {
+        // Keeps from referencing newer resources/manifest attributes introduced after 30
+        minCompileSdk = 30
+    }
+
     buildFeatures { 
         // AGP 8 disables buildConfig generation by default. We set this to true
         // to resstore BuildConfig.VERSION_NAME for both debug and release build types.

--- a/documents/ANDROID.md
+++ b/documents/ANDROID.md
@@ -34,9 +34,9 @@ a dependency of the aws-iot-device-sdk-android library.
 ## Installation
 
 ### Minimum requirements
-* Java 11+ ([Download and Install Java](https://www.java.com/en/download/help/download_options.html))
+* Java 17+ ([Download and Install Java](https://www.java.com/en/download/help/download_options.html))
   * [Set JAVA_HOME](./PREREQUISITES.md#set-java_home)
-* Gradle 7.4.2 ([Download and Install Gradle](https://gradle.org/install/))
+* Gradle 8.5.1+ ([Download and Install Gradle](https://gradle.org/install/))
 * Android SDK 24 ([Download SDK Manager](https://developer.android.com/tools/releases/platform-tools#downloads))
   * [Set ANDROID_HOME](./PREREQUISITES.md#set-android_home)
 

--- a/samples/Android/app/build.gradle
+++ b/samples/Android/app/build.gradle
@@ -78,7 +78,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    api 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk-android:1.27.1'
+    api 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk-android:1.27.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core:1.2.0'

--- a/samples/Android/app/build.gradle
+++ b/samples/Android/app/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.2"
+        classpath "com.android.tools.build:gradle:8.5.1"
     }
 }
 
@@ -17,17 +17,36 @@ repositories {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    namespace "software.amazon.awssdk.iotsamples"
+    compileSdk 35
 
     defaultConfig {
         applicationId "software.amazon.awssdk.iotsamples"
         minSdkVersion 24
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    // Make sure JNI libs are packaged UNCOMPRESSED (so AGP can align them)
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging false
+        }
+    }
+
+    buildFeatures {
+        buildConfig true
+    }
+
+    publishing {
+        // Creates the 'release' SoftwareComponent used by maven-publish
+        singleVariant("release") {
+            withSourcesJar()
+        }
+        // If you also need debug: singleVariant("debug")
     }
 
     sourceSets {
@@ -59,7 +78,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    api 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk-android:1.27.0'
+    api 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk-android:1.27.1'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core:1.2.0'

--- a/samples/Android/app/src/main/AndroidManifest.xml
+++ b/samples/Android/app/src/main/AndroidManifest.xml
@@ -1,21 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="software.amazon.awssdk.iotsamples">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+  <application
+      android:allowBackup="true"
+      android:label="@string/app_name"
+      android:supportsRtl="true">
 
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-    </application>
+    <activity
+        android:name="software.amazon.awssdk.iotsamples.MainActivity"
+        android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
 
+  </application>
 </manifest>

--- a/samples/Android/app/src/main/java/software/amazon/awssdk/iotsamples/MainActivity.java
+++ b/samples/Android/app/src/main/java/software/amazon/awssdk/iotsamples/MainActivity.java
@@ -105,10 +105,15 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
 
         sampleSelect = findViewById(R.id.sampleSelect);
         ArrayAdapter<String> samplesAdapter = new ArrayAdapter<>(
-                this, R.layout.support_simple_spinner_dropdown_item, SAMPLES.keySet().toArray(new String[0])
+            this,
+            android.R.layout.simple_spinner_dropdown_item,
+            SAMPLES.keySet().toArray(new String[0])
         );
+        samplesAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         sampleSelect.setAdapter(samplesAdapter);
         sampleSelect.setOnItemSelectedListener(this);
+
+        
 
         loadAssets();
         context = this;

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.38.7</version>
+      <version>0.38.11</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/sdk/tests/android/testapp/build.gradle
+++ b/sdk/tests/android/testapp/build.gradle
@@ -62,6 +62,10 @@ android {
         targetCompatibility = 1.8
         coreLibraryDesugaringEnabled true
     }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {

--- a/sdk/tests/android/testapp/build.gradle
+++ b/sdk/tests/android/testapp/build.gradle
@@ -60,6 +60,7 @@ android {
     compileOptions {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
+        coreLibraryDesugaringEnabled true
     }
 }
 
@@ -71,6 +72,7 @@ dependencies {
     implementation 'androidx.core:core:1.2.0'
     implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"
 
     testImplementation 'junit:junit:4.13'
 

--- a/sdk/tests/android/testapp/build.gradle
+++ b/sdk/tests/android/testapp/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.2"
+        classpath "com.android.tools.build:gradle:8.5.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/sdk/tests/android/testapp/build.gradle
+++ b/sdk/tests/android/testapp/build.gradle
@@ -22,8 +22,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    namespace "software.amazon.awssdk.iottest"   // required on AGP 8+
+    compileSdkVersion 35
 
     defaultConfig {
         applicationId "software.amazon.awssdk.iottest"
@@ -54,6 +54,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    packagingOptions { jniLibs { useLegacyPackaging false } }
+    
     compileOptions {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8

--- a/sdk/tests/android/testapp/build.gradle
+++ b/sdk/tests/android/testapp/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.0'
+    ext.kotlin_version = '1.9.24'
     repositories {
         google()
         mavenCentral()
@@ -56,7 +56,7 @@ android {
     }
 
     packagingOptions { jniLibs { useLegacyPackaging false } }
-    
+
     compileOptions {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8

--- a/sdk/tests/android/testapp/src/main/AndroidManifest.xml
+++ b/sdk/tests/android/testapp/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="software.amazon.awssdk.iottest">
 
     <application
         android:allowBackup="true"
@@ -9,13 +8,13 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity 
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>
-
 </manifest>

--- a/sdk/tests/android/testapp/src/main/AndroidManifest.xml
+++ b/sdk/tests/android/testapp/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play must support 16 KB page sizes on 64-bit devices as outlined here: https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

The most significant changes are bumping the gradle wrapper from 7.4.2 to 8.5.1 which also requires a bump of JDK from 11 to 17+.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
