### PR TITLE
Expose TLS configuration in AwsIotMqtt5ClientBuilder

### DIFF
--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSigningAlgori
 import software.amazon.awssdk.crt.http.HttpProxyOptions;
 import software.amazon.awssdk.crt.io.ClientBootstrap;
 import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsCipherPreference;
 import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextCustomKeyOperationOptions;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
@@ -646,6 +647,20 @@ public class AwsIotMqtt5ClientBuilder extends software.amazon.awssdk.crt.CrtReso
      */
     public AwsIotMqtt5ClientBuilder withMinimumTlsVersion(TlsContextOptions.TlsVersions minimumTlsVersion) {
         this.configTls.minTlsVersion = minimumTlsVersion;
+        return this;
+    }
+
+    /**
+     * Sets the TLS cipher preference.
+     * <p>
+     * Note: Setting a custom TLS cipher preference is supported only on Unix-like platforms (e.g., Linux, Android) when
+     * using the s2n library. Other platforms currently support only `TLS_CIPHER_SYSTEM_DEFAULT`.
+     *
+     * @param tlsCipherPreference - The TLS cipher preference to use.
+     * @return - The AwsIotMqtt5ClientBuilder
+     */
+    public AwsIotMqtt5ClientBuilder withTlsCipherPreference(TlsCipherPreference tlsCipherPreference) {
+        this.configTls.tlsCipherPreference = tlsCipherPreference;
         return this;
     }
 

--- a/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
+++ b/sdk/src/main/java/software/amazon/awssdk/iot/AwsIotMqtt5ClientBuilder.java
@@ -639,6 +639,17 @@ public class AwsIotMqtt5ClientBuilder extends software.amazon.awssdk.crt.CrtReso
     }
 
     /**
+     * Sets the minimum TLS version that is acceptable for connection establishment.
+     *
+     * @param minimumTlsVersion - Minimum TLS version allowed in client connections.
+     * @return - The AwsIotMqtt5ClientBuilder
+     */
+    public AwsIotMqtt5ClientBuilder withMinimumTlsVersion(TlsContextOptions.TlsVersions minimumTlsVersion) {
+        this.configTls.minTlsVersion = minimumTlsVersion;
+        return this;
+    }
+
+    /**
      * Constructs an MQTT5 client object configured with the options set.
      * @return A MQTT5ClientOptions
      */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Expose the minimum TLS version and cipher preference in AwsIotMqtt5ClientBuilder.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
