### PR TITLE
aws-crt-java 0.38.12 -> 0.38.13

### DIFF
--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -114,7 +114,7 @@ repositories {
 }
 
 dependencies {
-    api 'software.amazon.awssdk.crt:aws-crt-android:0.38.12'
+    api 'software.amazon.awssdk.crt:aws-crt-android:0.38.13'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.google.code.gson:gson:2.9.0'

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.38.12</version>
+      <version>0.38.13</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
New version of aws-crt-java adds proguard protections against minify and shrinking the native library.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
