### PR TITLE
gson 2.9.0 -> 2.10.1

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.9.0</version>
+      <version>2.10.1</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
gson 2.9.0 has an incompatibility with Java 21+ due to its stronger module encapsulation.
Related issue: https://github.com/google/gson/issues/1875 
Related changelog with fix: https://github.com/google/gson/blob/main/CHANGELOG.md#version-2100

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
