### PR TITLE
Add TLS 1.3 support on macOS via s2n-tls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,57 @@ jobs:
         mvn test -Dtest=Mqtt5BuilderTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
         source utils/test_cleanup.sh
 
+  # Test macOS with s2n-tls backend (TLS 1.3) instead of Apple Secure Transport
+  osx-s2n-tls:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 8
+          - 11
+          - 17
+    env:
+      AWS_CRT_USE_NON_FIPS_TLS_13: "1"
+    permissions:
+      id-token: write # This is required for requesting the JWT
+    steps:
+    - name: Checkout Sources
+      uses: actions/checkout@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3.14.1
+      with:
+        distribution: ${{ matrix.version == 8 && 'corretto' || 'temurin' }}
+        java-version: ${{ matrix.version }}
+        cache: maven
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+    - name: configure AWS credentials (MQTT5)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CI_MQTT5_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Service tests
+      run: |
+        source utils/test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt us-east-1
+        mvn test -Dtest=ShadowTests -Dsurefire.failIfNoSpecifiedTests=false
+        mvn test -Dtest=JobsTests -Dsurefire.failIfNoSpecifiedTests=false
+        mvn test -Dtest=IdentityTests -Dsurefire.failIfNoSpecifiedTests=false
+        source utils/test_cleanup.sh
+    - name: MQTT311 tests
+      run: |
+        source utils/test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt us-east-1
+        mvn test -Dtest=MqttBuilderTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
+        source utils/test_cleanup.sh
+    - name: MQTT5 tests
+      run: |
+        source utils/test_setup.sh s3://iot-sdk-ci-bucket-us-east1/IotUsProdMqtt5EnvironmentVariables.txt us-east-1
+        mvn test -Dtest=Mqtt5BuilderTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
+        source utils/test_cleanup.sh
+
   linux-java-compat:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ If you have a support plan with [AWS Support](https://aws.amazon.com/premiumsupp
 
 #### Mac-Only TLS Behavior
 
-> [!NOTE]
-> This SDK does not support TLS 1.3 on macOS. Support for TLS 1.3 on macOS is planned for a future release.
+By default, macOS uses Apple Secure Transport as the TLS implementation, which supports up to TLS 1.2. To enable TLS 1.3 on macOS, set the environment variable `AWS_CRT_USE_NON_FIPS_TLS_13=1` before running your application. This switches the TLS backend to s2n-tls with aws-lc at runtime.
 
-Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  Beginning in v1.7.3, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+> [!IMPORTANT]
+> Enabling `AWS_CRT_USE_NON_FIPS_TLS_13` trades FIPS compliance and macOS Keychain/PKCS#12 integration for TLS 1.3 support. This variable has no effect on Linux or Windows.
+
+Please note that when using the default Apple Secure Transport backend, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
 
 ```
 static: certificate has an existing certificate-key pair that was previously imported into the Keychain.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The AWS IoT Device SDK for Java v2 connects your Java applications and devices t
 * [Getting Started](#getting-started)
 * [Samples](samples)
 * [MQTT5 User Guide](./documents/MQTT5_Userguide.md)
+* [Specifics](#specifics)
 * [Getting Help](#getting-help)
 * [Resources](#resources)
 
@@ -89,6 +90,24 @@ Check out the [samples](samples) directory for working code examples that demons
 
 The samples provide ready-to-run code with detailed setup instructions for each authentication method and use case.
 
+## Specifics
+
+#### Mac-Only TLS 1.3
+
+By default, macOS uses Apple Secure Transport as the TLS implementation, which supports up to TLS 1.2. To enable TLS 1.3 on macOS, set the environment variable `AWS_CRT_USE_NON_FIPS_TLS_13=1` before running your application. This switches the TLS backend to s2n-tls with aws-lc at runtime.
+
+> [!IMPORTANT]
+> Enabling `AWS_CRT_USE_NON_FIPS_TLS_13` trades FIPS compliance and macOS Keychain/PKCS#12 integration for TLS 1.3 support. This variable has no effect on Linux or Windows.
+
+#### Mac Keychain
+
+When using the default Apple Secure Transport backend, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically. When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+
+```
+static: certificate has an existing certificate-key pair that was previously imported into the Keychain.
+ Using key from Keychain instead of the one provided.
+```
+
 ## Getting Help
 
 The best way to interact with our team is through GitHub.
@@ -97,20 +116,6 @@ The best way to interact with our team is through GitHub.
 * Create an [issue](https://github.com/aws/aws-iot-device-sdk-java-v2/issues/new/choose): New feature request or file a bug
 
 If you have a support plan with [AWS Support](https://aws.amazon.com/premiumsupport/), you can also create a new support case.
-
-#### Mac-Only TLS Behavior
-
-By default, macOS uses Apple Secure Transport as the TLS implementation, which supports up to TLS 1.2. To enable TLS 1.3 on macOS, set the environment variable `AWS_CRT_USE_NON_FIPS_TLS_13=1` before running your application. This switches the TLS backend to s2n-tls with aws-lc at runtime.
-
-> [!IMPORTANT]
-> Enabling `AWS_CRT_USE_NON_FIPS_TLS_13` trades FIPS compliance and macOS Keychain/PKCS#12 integration for TLS 1.3 support. This variable has no effect on Linux or Windows.
-
-Please note that when using the default Apple Secure Transport backend, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
-
-```
-static: certificate has an existing certificate-key pair that was previously imported into the Keychain.
- Using key from Keychain instead of the one provided.
-```
 
 ## Resources
 

--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -114,7 +114,7 @@ repositories {
 }
 
 dependencies {
-    api 'software.amazon.awssdk.crt:aws-crt-android:0.45.0'
+    api 'software.amazon.awssdk.crt:aws-crt-android:0.47.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.google.code.gson:gson:2.9.0'

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.45.0</version>
+      <version>0.47.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Add TLS 1.3 support on macOS via s2n-tls

- Bump `awscrt` to 0.47.0, which adds runtime support for switching to s2n-tls on macOS
- Document the `AWS_CRT_USE_NON_FIPS_TLS_13` environment variable in the README
- Add `osx-s2n-tls` CI job to exercise the s2n-tls backend on macOS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
