### PR TITLE
fix(security): Remove GPG key leak from build logs

### DIFF
--- a/android/iotdevicesdk/build.gradle
+++ b/android/iotdevicesdk/build.gradle
@@ -61,10 +61,10 @@ android {
         }
     }
 
-    buildFeatures { 
+    buildFeatures {
         // AGP 8 disables buildConfig generation by default. We set this to true
         // to resstore BuildConfig.VERSION_NAME for both debug and release build types.
-        buildConfig true 
+        buildConfig true
     }
 
     // Make the 'release' SoftwareComponent available for publishing on AGP 8
@@ -203,7 +203,6 @@ afterEvaluate {
                     (String) project.property("signingKey"),
                     (String) project.property("signingPassword")
                 )
-                println("key=" + project.property("signingKey"))
                 sign(publications)
             }
         }

--- a/codebuild/cd/deploy-android.sh
+++ b/codebuild/cd/deploy-android.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 set -o pipefail # Ensure if any part of a pipeline fails, it propogates the error through the pipeline
 
 git submodule update --init

--- a/utils/publish-release.sh
+++ b/utils/publish-release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
 
 # Redirect output to stderr.
 exec 1>&2


### PR DESCRIPTION
*Description of changes:*

- Removed println("key=" + project.property("signingKey")) from `build.gradle`. 
- Changed set -ex to set -e in `deploy-android.sh` to disable bash xtrace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
