### PR TITLE
fix script injection issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,10 @@ jobs:
         Title: ${{ github.event.inputs.release_title }}
         ReleaseType: ${{ github.event.inputs.release_type }}
       run: |
-        # Escape Special characters
-        Title="${Title//\`/}"
-        Title="${Title//\$/}"
-        Title="${Title//\"/\\\"}"
-        Title="${Title//\'/\\\'}"
+        # Escape special characters
+        Title=$(echo ${Title//[\"]\\\"})
+        Title=$(echo ${Title//[\']\\\'})
+        Title=$(echo ${Title//[\$]})
 
         ./utils/publish-release.sh "$ReleaseType" "$Title"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,15 +33,15 @@ jobs:
 
     - name: Make new release
       env:
-        Title: ${{ github.event.inputs.release_title }}
-        ReleaseType: ${{ github.event.inputs.release_type }}
+        TITLE: ${{ github.event.inputs.release_title }}
+        RELEASE_TYPE: ${{ github.event.inputs.release_type }}
       run: |
         # Escape special characters
-        Title=$(echo ${Title//[\"]\\\"})
-        Title=$(echo ${Title//[\']\\\'})
-        Title=$(echo ${Title//[\$]})
+        TITLE=$(echo ${TITLE//[\"]\\\"})
+        TITLE=$(echo ${TITLE//[\']\\\'})
+        TITLE=$(echo ${TITLE//[\$]})
 
-        ./utils/publish-release.sh "$ReleaseType" "$Title"
+        ./utils/publish-release.sh "$RELEASE_TYPE" "$TITLE"
 
     - name: Generate documentation
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,15 @@ jobs:
     - name: Make new release
       env:
         Title: ${{ github.event.inputs.release_title }}
+        ReleaseType: ${{ github.event.inputs.release_type }}
       run: |
-        # Escape special characters
-        Title=$(echo ${Title//[\"]\\\"})
-        Title=$(echo ${Title//[\']\\\'})
-        Title=$(echo ${Title//[\$]})
+        # Escape Special characters
+        Title="${Title//\`/}"
+        Title="${Title//\$/}"
+        Title="${Title//\"/\\\"}"
+        Title="${Title//\'/\\\'}"
 
-        ./utils/publish-release.sh "${{ github.event.inputs.release_type }}" "$Title"
+        ./utils/publish-release.sh "$ReleaseType" "$Title"
 
     - name: Generate documentation
       run: |


### PR DESCRIPTION
*Issue #, if available:*
Fixes GitHub Actions expression injection finding in release workflow.

*Description of changes:*
Moved `${{ }}` expression  from run to `env`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
